### PR TITLE
Small fixes, add :x

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -79,7 +79,7 @@ static void statusbar(EditorWin *win) {
 	          text_modified(win->text) ? "[+]" : "",
 	          vis->recording ? "recording": "");
 	char buf[win->width + 1];
-	int len = snprintf(buf, win->width, "%d, %d", line, col);
+	int len = snprintf(buf, win->width, "%zd, %zd", line, col);
 	if (len > 0) {
 		buf[len] = '\0';
 		mvwaddstr(win->statuswin, 0, win->width - len - 1, buf);

--- a/config.def.h
+++ b/config.def.h
@@ -53,7 +53,7 @@ static Command cmds[] = {
 	{ "^new$",           cmd_new,        false },
 	{ "^o(pen)?$",       cmd_open,       false },
 	{ "^qa(ll)?!?$",     cmd_qall,       false },
-	{ "^q(quit)?!?$",    cmd_quit,       false },
+	{ "^q(uit)?!?$",     cmd_quit,       false },
 	{ "^r(ead)?$",       cmd_read,       false },
 	{ "^sav(as)?$",      cmd_saveas,     false },
 	{ "^set?$",          cmd_set,        true  },

--- a/config.def.h
+++ b/config.def.h
@@ -63,6 +63,7 @@ static Command cmds[] = {
 	{ "^v(split)?$",     cmd_vsplit,     false },
 	{ "^wq!?$",          cmd_wq,         false },
 	{ "^w(rite)?$",      cmd_write,      false },
+	{ "^x(it)?!?$",      cmd_xit,        false },
 	{ /* array terminator */                   },
 };
 

--- a/text.c
+++ b/text.c
@@ -756,7 +756,7 @@ Text *text_load_fd(int fd) {
 }
 
 static void print_piece(Piece *p) {
-	fprintf(stderr, "index: %d\tnext: %d\tprev: %d\t len: %d\t data: %p\n", p->index,
+	fprintf(stderr, "index: %d\tnext: %d\tprev: %d\t len: %zd\t data: %p\n", p->index,
 		p->next ? p->next->index : -1,
 		p->prev ? p->prev->index : -1,
 		p->len, p->data);

--- a/vis.c
+++ b/vis.c
@@ -509,6 +509,8 @@ static bool cmd_new(Filerange*, const char *argv[]);
 static bool cmd_vnew(Filerange*, const char *argv[]);
 /* save the file displayed in the current window and close it */
 static bool cmd_wq(Filerange*, const char *argv[]);
+/* save the file displayed in the current window if it was changed, then close the window */
+static bool cmd_xit(Filerange*, const char *argv[]);
 /* save the file displayed in the current window to the name given.
  * do not change internal filname association. further :w commands
  * without arguments will still write to the old filename */
@@ -1378,6 +1380,15 @@ static bool cmd_quit(Filerange *range, const char *argv[]) {
 	if (!vis->windows)
 		quit(NULL);
 	return true;
+}
+
+static bool cmd_xit(Filerange *range, const char *argv[]) {
+	if (text_modified(vis->win->text) && !cmd_write(range, argv)) {
+		bool force = strchr(argv[0], '!') != NULL;
+		if (!force)
+			return false;
+	}
+	return cmd_quit(range, argv);
 }
 
 static bool cmd_bdelete(Filerange *range, const char *argv[]) {

--- a/window.c
+++ b/window.c
@@ -108,7 +108,7 @@ void window_selection_clear(Win *win) {
 static int window_numbers_width(Win *win) {
 	if (!win->winnum)
 		return 0;
-	return snprintf(NULL, 0, "%d", win->topline->lineno + win->height - 1) + 1;
+	return snprintf(NULL, 0, "%zd", win->topline->lineno + win->height - 1) + 1;
 }
 
 static void window_numbers_draw(Win *win) {


### PR DESCRIPTION
The result of trying out vis on the vis source code: Some small fixes and the addition of the :x vim command which I always use instead of :wq or :q