### PR TITLE
Use %zu format for size_t values

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -79,7 +79,7 @@ static void statusbar(EditorWin *win) {
 	          text_modified(win->text) ? "[+]" : "",
 	          vis->recording ? "recording": "");
 	char buf[win->width + 1];
-	int len = snprintf(buf, win->width, "%d, %d", line, col);
+	int len = snprintf(buf, win->width, "%zu, %zu", line, col);
 	if (len > 0) {
 		buf[len] = '\0';
 		mvwaddstr(win->statuswin, 0, win->width - len - 1, buf);

--- a/text.c
+++ b/text.c
@@ -756,7 +756,7 @@ Text *text_load_fd(int fd) {
 }
 
 static void print_piece(Piece *p) {
-	fprintf(stderr, "index: %d\tnext: %d\tprev: %d\t len: %d\t data: %p\n", p->index,
+	fprintf(stderr, "index: %d\tnext: %d\tprev: %d\t len: %zu\t data: %p\n", p->index,
 		p->next ? p->next->index : -1,
 		p->prev ? p->prev->index : -1,
 		p->len, p->data);

--- a/window.c
+++ b/window.c
@@ -108,7 +108,7 @@ void window_selection_clear(Win *win) {
 static int window_numbers_width(Win *win) {
 	if (!win->winnum)
 		return 0;
-	return snprintf(NULL, 0, "%d", win->topline->lineno + win->height - 1) + 1;
+	return snprintf(NULL, 0, "%zu", win->topline->lineno + win->height - 1) + 1;
 }
 
 static void window_numbers_draw(Win *win) {


### PR DESCRIPTION
This patch addresses a few warnings seen when building on x86_64, where size_t is 'long', not 'int'.

<pre>
~/repos/vis % make
cleaning
vis build options:
CFLAGS   = -D_DARWIN_C_SOURCE -std=c99 -Os -I. -DVERSION="devel" -DNDEBUG -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700
LDFLAGS  = -lc -lncurses
CC       = cc
ln -fs config.def.h config.h
CC editor.c
CC window.c
window.c:111:33: warning: format specifies type 'int' but the argument has type 'unsigned long' [-Wformat]
        return snprintf(NULL, 0, "%d", win->topline->lineno + win->height - 1) + 1;
                                  ~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                  %lu
/usr/include/secure/_stdio.h:56:62: note: expanded from macro 'snprintf'
  __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
                                                             ^
1 warning generated.
CC text.c
text.c:762:3: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
                p->len, p->data);
                ^~~~~~
1 warning generated.
</pre>