### PR TITLE
Fix openline command on the first line

### DIFF
--- a/vis.c
+++ b/vis.c
@@ -1126,9 +1126,14 @@ static void put(const Arg *arg) {
 }
 
 static void openline(const Arg *arg) {
-	movement(&(const Arg){ .i = arg->i == MOVE_LINE_NEXT ?
-	                       MOVE_LINE_END : MOVE_LINE_PREV });
-	insert_newline(NULL);
+	if (arg->i == MOVE_LINE_NEXT) {
+		movement(&(const Arg){ .i = MOVE_LINE_END });
+		insert_newline(NULL);
+	} else {
+		movement(&(const Arg){ .i = MOVE_LINE_START });
+		insert_newline(NULL);
+		movement(&(const Arg){ .i = MOVE_LINE_PREV });
+	}
 	switchmode(&(const Arg){ .i = VIS_MODE_INSERT });
 }
 


### PR DESCRIPTION
When on the first line, openline command wouldn't move the cursor to the
newly created line above the current line.