### PR TITLE
Add rudimentary markdown syntax support

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1218,5 +1218,36 @@ static Syntax syntaxes[] = {{
 		&colors[COLOR_BRACKETS],
 	}}
 },{
+	.name = "markdown",
+	.file = "\\.(md|mdwn)$",
+	.rules = {{
+		"(^#{1,6}.*$)", //titles
+		&colors[COLOR_SYNTAX5],
+	},{
+		"((\\* *){3,}|(_ *){3,}|(- *){3,})", // horizontal rules
+		&colors[COLOR_SYNTAX2],
+	},{
+		"(\\*\\*.*\\*\\*)|(__.*__)", // super-bolds
+		&colors[COLOR_SYNTAX4],
+	},{
+		"(\\*.*\\*)|(_.*_)", // bolds
+		&colors[COLOR_SYNTAX3],
+	},{
+		"(\\[.*\\]\\(.*\\))", //links
+		&colors[COLOR_SYNTAX6],
+	},{
+		"(^ *([-\\*\\+]|[0-9]+\\.))", //lists
+		&colors[COLOR_SYNTAX2],
+	},{
+		"(^( {4,}|\t+).*$)", // code blocks
+		&colors[COLOR_SYNTAX7],
+	},{
+		"(`+.*`+)", // inline code
+		&colors[COLOR_SYNTAX7],
+	},{
+		"(^>+.*)", // quotes
+		&colors[COLOR_SYNTAX7],
+	}}
+	},{
 	/* empty last element, array terminator */
 }};


### PR DESCRIPTION
The spec is here: http://daringfireball.net/projects/markdown/syntax
Currently, it doesn't support Setext headers and hard-wrapped quotes.
Also, the colours are ugly, feel free to implement a better scheme.