### PR TITLE
make J (op_join) work like it does in vim

### DIFF
--- a/vis.c
+++ b/vis.c
@@ -672,7 +672,8 @@ static void op_join(OperatorContext *c) {
 		}
 	} while (pos != prev_pos);
 
-	window_cursor_to(vis->win->win, c->range.start);
+	size_t end = text_line_lastchar(txt, c->range.end);
+	window_cursor_to(vis->win->win, end);
 	editor_draw(vis);
 }
 

--- a/vis.c
+++ b/vis.c
@@ -655,6 +655,7 @@ static void op_case_change(OperatorContext *c) {
 static void op_join(OperatorContext *c) {
 	Text *txt = vis->win->text;
 	size_t pos = text_line_begin(txt, c->range.end), prev_pos;
+	size_t eolprev = text_line_lastchar(txt, prev_pos);
 	Filerange sel = window_selection_get(vis->win->win);
 	/* if a selection ends at the begin of a line, skip line break */
 	if (pos == c->range.end && text_range_valid(&sel))
@@ -672,8 +673,7 @@ static void op_join(OperatorContext *c) {
 		}
 	} while (pos != prev_pos);
 
-	size_t end = text_line_lastchar(txt, c->range.end);
-	window_cursor_to(vis->win->win, end);
+	window_cursor_to(vis->win->win, eolprev);
 	editor_draw(vis);
 }
 


### PR DESCRIPTION
Steps to duplicate the non-vim like behavior in vis:
1. open vis.c in vis (at the top of the file)
2. press J 3 times
3. Note that one more press of J doesn't join the next line, but it would in vim.

This change makes 3 possible, but the cursor position looks like it is off by one from what vim would do.