### PR TITLE
Change ledger syntax regex to work with BSD regex

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1263,16 +1263,16 @@ static Syntax syntaxes[] = {{
 		"^[;#].*",
 		&colors[COLOR_COMMENT],
 	},{ /* value tag */
-		"(  |\t|^ )+?; :([^ ][^:]*:)+[ \\t]*$",
+		"(  |\t|^ )*; :([^ ][^:]*:)+[ \\t]*$",
 		&colors[COLOR_DATATYPE],
 	},{ /* typed tag */
-		"(  |\t|^ )+?; [^:]+::.*",
+		"(  |\t|^ )*; [^:]+::.*",
 		&colors[COLOR_DATATYPE],
 	},{ /* tag */
-		"(  |\t|^ )+?; [^:]+:.*",
+		"(  |\t|^ )*; [^:]+:.*",
 		&colors[COLOR_TYPE],
 	},{ /* metadata */
-		"(  |\t|^ )+?;.*",
+		"(  |\t|^ )*;.*",
 		&colors[COLOR_CONSTANT],
 	},{ /* date */
 		"^[0-9][^ \t]+",
@@ -1281,7 +1281,7 @@ static Syntax syntaxes[] = {{
 		"^[ \t]+[a-zA-Z:'!*()%&]+",
 		&colors[COLOR_IDENTIFIER]
 	},{ /* amount */
-		"(  |\t)[^;]+?",
+		"(  |\t)[^;]*",
 		&colors[COLOR_LITERAL],
 	},{ /* automated transaction */
 		"^[=~].*",


### PR DESCRIPTION
A fix for issue #22

Highlighting for http://www.ledger-cli.org/3.0/doc/ledger3.html#Example-Journal-File is the same before fix (compiled in Linux) as after the fix (compiled in Linux and OS X)