### PR TITLE
Fix two possible NULL dereferences

### DIFF
--- a/text.c
+++ b/text.c
@@ -315,6 +315,8 @@ static void span_init(Span *span, Piece *start, Piece *end) {
 static void span_swap(Text *txt, Span *old, Span *new) {
 	if (old->len == 0 && new->len == 0) {
 		return;
+	} else if (new->end == NULL || new->start == NULL) {
+		return;
 	} else if (old->len == 0) {
 		/* insert new span */
 		new->start->prev->next = new->start;


### PR DESCRIPTION
In text.c:849, new_start and new_end are set to NULL,
if midway_start and midway_end are NULL too,
this leads to NULL-dereferences,
in the span_swap function.