### PR TITLE
Cindent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include config.mk
 
-SRC = editor.c window.c text.c text-motions.c text-objects.c register.c buffer.c ring-buffer.c
+SRC = editor.c window.c text.c text-motions.c text-objects.c register.c buffer.c ring-buffer.c indent.c
 HDR := ${SRC:.c=.h} macro.h syntax.h util.h config.def.h
 SRC += vis.c
 OBJ = ${SRC:.c=.o}

--- a/config.def.h
+++ b/config.def.h
@@ -557,6 +557,7 @@ static KeyBinding vis_mode_insert[] = {
 	{ { CONTROL('X'), CONTROL('Y') }, wslide,       { .i = +1                } },
 	{ { NONE('\t')              }, insert_tab,      { NULL                   } },
 	{ { KEY(END)                }, movement,        { .i = MOVE_LINE_END     } },
+	{ { CONTROL('F'),           }, reindent_line,   { NULL                   } },
 	{ /* empty last element, array terminator */                               },
 };
 

--- a/config.def.h
+++ b/config.def.h
@@ -218,6 +218,7 @@ static KeyBinding vis_operators[] = {
 	{ { NONE('p')               }, put,           { .i = +1              } },
 	{ { NONE('P')               }, put,           { .i = -1              } },
 	{ { NONE('>')               }, operator,      { .i = OP_SHIFT_RIGHT  } },
+	{ { NONE('=')               }, operator,      { .i = OP_REINDENT     } },
 	{ { NONE('<')               }, operator,      { .i = OP_SHIFT_LEFT   } },
 	{ { NONE('g'), NONE('U')    }, changecase,    { .i = +1              } },
 	{ { NONE('~')               }, changecase,    { .i =  0              } },

--- a/editor.h
+++ b/editor.h
@@ -112,9 +112,9 @@ struct Editor {
 	Regex *search_pattern;            /* last used search pattern */
 	void (*windows_arrange)(Editor*); /* current layout which places the windows */
 	void (*statusbar)(EditorWin*);    /* configurable user hook to draw statusbar */
+	size_t (*insert_indent)(Text *text, size_t line_begin); /* user hook that inserts indentation for the current line */
 	int tabwidth;                     /* how many spaces should be used to display a tab */
 	bool expandtab;                   /* whether typed tabs should be converted to spaces */
-	bool autoindent;                  /* whether indentation should be copied from previous line on newline */
 };
 
 Editor *editor_new(int width, int height);

--- a/editor.h
+++ b/editor.h
@@ -112,7 +112,8 @@ struct Editor {
 	Regex *search_pattern;            /* last used search pattern */
 	void (*windows_arrange)(Editor*); /* current layout which places the windows */
 	void (*statusbar)(EditorWin*);    /* configurable user hook to draw statusbar */
-	size_t (*insert_indent)(Text *text, size_t line_begin); /* user hook that inserts indentation for the current line */
+	/* user hook that inserts indentation for the current line */
+	size_t (*insert_indent)(Text *text, size_t line_begin, bool new_line);
 	int tabwidth;                     /* how many spaces should be used to display a tab */
 	bool expandtab;                   /* whether typed tabs should be converted to spaces */
 };

--- a/indent.c
+++ b/indent.c
@@ -22,7 +22,15 @@ size_t copy_indent_from_line(Text *text, size_t pos, size_t line) {
 	return insert_copy_of_range(text, pos, &indent_range);
 }
 
-size_t autoindent(Text *text, size_t line_begin) {
+size_t delete_indent(Text *text, size_t line_begin) {
+	size_t line_start = text_line_start(text, line_begin);
+	size_t len = line_start - line_begin;
+	text_delete(text, line_begin, len);
+	return line_start;
+}
+
+size_t autoindent(Text *text, size_t line_begin, bool new_line) {
+	(void)new_line;
 	size_t prev_line = text_line_prev(text, line_begin);
 	return copy_indent_from_line(text, line_begin, prev_line);
 }

--- a/indent.c
+++ b/indent.c
@@ -1,0 +1,28 @@
+#include <stdlib.h>
+#include "text-motions.h"
+#include "text.h"
+
+size_t insert_copy_of_range(Text *text, size_t pos, Filerange *range) {
+	size_t len = range->end - range->start;
+	char *buf = malloc(len);
+	if (!buf)
+		return pos;
+	len = text_bytes_get(text, range->start, len, buf);
+	bool insert_res = text_insert(text, pos, buf, len);
+	free(buf);
+	if (!insert_res)
+		return pos;
+	return pos + len;
+}
+
+size_t copy_indent_from_line(Text *text, size_t pos, size_t line) {
+	size_t line_begin = text_line_begin(text, line);
+	size_t line_start = text_line_start(text, line_begin);
+	Filerange indent_range = { line_begin, line_start };
+	return insert_copy_of_range(text, pos, &indent_range);
+}
+
+size_t autoindent(Text *text, size_t line_begin) {
+	size_t prev_line = text_line_prev(text, line_begin);
+	return copy_indent_from_line(text, line_begin, prev_line);
+}

--- a/indent.c
+++ b/indent.c
@@ -1,6 +1,10 @@
 #include <stdlib.h>
+#include <ctype.h>
 #include "text-motions.h"
 #include "text.h"
+
+#define SHIFT "\t"
+#define STRINGLEN(x) sizeof(x)-1
 
 size_t insert_copy_of_range(Text *text, size_t pos, Filerange *range) {
 	size_t len = range->end - range->start;
@@ -33,4 +37,144 @@ size_t autoindent(Text *text, size_t line_begin, bool new_line) {
 	(void)new_line;
 	size_t prev_line = text_line_prev(text, line_begin);
 	return copy_indent_from_line(text, line_begin, prev_line);
+}
+
+/* extraordinary lines like preprocessor directives or empty lines get no
+ * indentation */
+static bool line_is_extraordinary(Text *text, size_t line) {
+	size_t start = text_line_start(text, line);
+	char start_c;
+	if (!text_byte_get(text, start, &start_c))
+		return true;
+	/* an empty line or one starting with '#' is extraordinary */
+	return start_c == '#' || start_c == '\r' || start_c == '\n';
+}
+
+/* search previous line that is not extraordinary */
+static size_t prev_normal_line(Text *text, size_t pos) {
+	do {
+		size_t new_pos = text_line_prev(text, pos);
+		if (new_pos == pos)
+			return pos;
+		pos = new_pos;
+	} while (line_is_extraordinary(text, pos));
+	return pos;
+}
+
+static size_t comment_block_heuristic(Text *text, size_t pos, bool newline) {
+	/* comment block heuristic: if previous line begins with '/''*' or "* "
+	 * then start line with "* " */
+	size_t prev_line = text_line_prev(text, pos);
+	size_t prev_start = text_line_start(text, prev_line);
+	char prev_start_c;
+	char next_c;
+	if (!text_byte_get(text, prev_start, &prev_start_c)
+	    || (prev_start_c != '*' && prev_start_c != '/')
+	    || !text_byte_get(text, prev_start+1, &next_c))
+		return EPOS;
+
+	size_t prev_last = text_line_lastchar(text, prev_start);
+	char prev_last_c;
+	char prev_c;
+	/* exception: previous line ends with '*''/' */
+	bool comment_ends = text_byte_get(text, prev_last, &prev_last_c)
+	                    && prev_last_c == '/'
+	                    && text_byte_get(text, prev_last-1, &prev_c)
+	                    && prev_c == '*'
+	                    && (prev_start_c != '/' || prev_last != prev_start+2);
+
+	if (prev_start_c == '/' && next_c == '*' && !comment_ends) {
+		pos = copy_indent_from_line(text, pos, prev_line);
+		if (text_insert(text, pos, " ", 1))
+			pos++;
+		if (newline && text_insert(text, pos, "* ", 2))
+			pos += 2;
+		return pos;
+	}
+	if (prev_start_c == '*' && (isspace(next_c) || next_c == '/')) {
+		if (comment_ends) {
+			/* reduce previous indent by the last space */
+			/* TODO: ensure it is actually a space and not a tab, etc. */
+			size_t prev_begin = text_line_begin(text, prev_start);
+			if (prev_start == prev_begin)
+				return EPOS;
+
+			Filerange range = { prev_begin, prev_start-1 };
+			return insert_copy_of_range(text, pos, &range);
+		} else {
+			pos = copy_indent_from_line(text, pos, prev_line);
+			if (newline && text_insert(text, pos, "* ", 2))
+				pos += 2;
+			return pos;
+		}
+	}
+	return EPOS;
+}
+
+static bool is_label(Text *text, size_t pos) {
+	size_t lastchar = text_line_lastchar(text, pos);
+	char last_c;
+	if (!text_byte_get(text, lastchar, &last_c))
+		return false;
+	/* decide whether it is a label. TODO: Would be more robust to check
+	 * for identifier :/default : or case .*: at the beginning of the
+	 * line. */
+	return last_c == ':';
+}
+
+/* If line is a label, indent at the same level as the current block
+ * opened (typically 1 indent less than normal statements) */
+size_t label_heuristic(Text *text, size_t pos) {
+	if (!is_label(text, pos))
+		return EPOS;
+
+	size_t block_begin = text_bracket_match_(text, pos, -1, '}', '{');
+	if (block_begin == pos)
+		return EPOS;
+	return copy_indent_from_line(text, pos, block_begin);
+}
+
+size_t cindent(Text *text, size_t line_begin, bool newline) {
+	size_t pos = line_begin;
+
+	size_t start = text_line_start(text, pos);
+	char start_c;
+	if (text_byte_get(text, start, &start_c)) {
+		/* if line begins with '}' copy indent from line with the
+		 * opening brace. */
+		if (start_c == '}') {
+			size_t block_begin = text_bracket_match(text, start);
+			if (block_begin != start_c)
+				return copy_indent_from_line(text, pos, block_begin);
+		}
+	}
+
+	/* if line is extraordinary, then reset indent to zero.
+	 * newlines are not finished yet and should therefore not be considered
+	 * like an empty line here. */
+	if (!newline && line_is_extraordinary(text, pos))
+		return pos;
+
+	size_t comment_pos = comment_block_heuristic(text, pos, newline);
+	if (comment_pos != EPOS)
+		return comment_pos;
+
+	size_t label_pos = label_heuristic(text, pos);
+	if (label_pos != EPOS)
+		return label_pos;
+
+	/* if previous line ends in { or was a label, increase indent */
+	size_t normal_line = prev_normal_line(text, pos);
+	size_t lastchar = text_line_lastchar(text, normal_line);
+	char last_c;
+	if ((text_byte_get(text, lastchar, &last_c) && last_c == '{')
+	    || is_label(text, normal_line)) {
+		pos = copy_indent_from_line(text, pos, normal_line);
+		if (text_insert(text, pos, SHIFT, STRINGLEN(SHIFT)))
+			pos += STRINGLEN(SHIFT);
+		return pos;
+	}
+
+	/* default: copy indent from previous (non-extraordinary) line */
+	return copy_indent_from_line(text, pos, normal_line);
 }

--- a/indent.h
+++ b/indent.h
@@ -1,7 +1,10 @@
 #ifndef INDENT_H
 #define INDENT_H
 
+/* delete indentation of line, return previous line start. */
+size_t delete_indent(Text *text, size_t line_begin);
+
 /* indent by copying the indentation of the previous line. */
-size_t autoindent(Text *text, size_t line_begin);
+size_t autoindent(Text *text, size_t line_begin, bool new_line);
 
 #endif

--- a/indent.h
+++ b/indent.h
@@ -1,0 +1,7 @@
+#ifndef INDENT_H
+#define INDENT_H
+
+/* indent by copying the indentation of the previous line. */
+size_t autoindent(Text *text, size_t line_begin);
+
+#endif

--- a/indent.h
+++ b/indent.h
@@ -1,10 +1,16 @@
 #ifndef INDENT_H
 #define INDENT_H
 
+#include <stdbool.h>
+#include <stddef.h>
+#include "text.h"
+
 /* delete indentation of line, return previous line start. */
 size_t delete_indent(Text *text, size_t line_begin);
 
 /* indent by copying the indentation of the previous line. */
-size_t autoindent(Text *text, size_t line_begin, bool new_line);
+size_t autoindent(Text *text, size_t line_begin, bool newline);
+/* indentation heuristic for the C language. */
+size_t cindent(Text *text, size_t line_begin, bool newline);
 
 #endif

--- a/text-motions.h
+++ b/text-motions.h
@@ -75,6 +75,7 @@ size_t text_section_prev(Text*, size_t pos);
 */
 /* search coresponding '(', ')', '{', '}', '[', ']', '>', '<', '"', ''' */
 size_t text_bracket_match(Text*, size_t pos);
+size_t text_bracket_match_(Text*, size_t pos, int dir, char inc, char search);
 
 /* search the given regex pattern in either forward or backward direction,
  * starting from pos. does wrap around if no match was found. */

--- a/vis.c
+++ b/vis.c
@@ -1393,6 +1393,7 @@ static bool cmd_set(Filerange *range, const char *argv[]) {
 
 	enum {
 		OPTION_AUTOINDENT,
+		OPTION_CINDENT,
 		OPTION_EXPANDTAB,
 		OPTION_TABWIDTH,
 		OPTION_SYNTAX,
@@ -1401,6 +1402,7 @@ static bool cmd_set(Filerange *range, const char *argv[]) {
 
 	static OptionDef options[] = {
 		[OPTION_AUTOINDENT] = { "^(autoindent|ai)$", OPTION_TYPE_BOOL   },
+		[OPTION_CINDENT]    = { "^(cindent|ci)$",    OPTION_TYPE_BOOL   },
 		[OPTION_EXPANDTAB]  = { "^(expandtab|et)$",  OPTION_TYPE_BOOL   },
 		[OPTION_TABWIDTH]   = { "^(tabwidth|tw)$",   OPTION_TYPE_NUMBER },
 		[OPTION_SYNTAX]     = { "^syntax$",          OPTION_TYPE_STRING },
@@ -1473,6 +1475,9 @@ static bool cmd_set(Filerange *range, const char *argv[]) {
 		break;
 	case OPTION_AUTOINDENT:
 		vis->insert_indent = arg.b ? autoindent : NULL;
+		break;
+	case OPTION_CINDENT:
+		vis->insert_indent = arg.b ? cindent : NULL;
 		break;
 	case OPTION_TABWIDTH:
 		editor_tabwidth_set(vis, arg.i);

--- a/vis.c
+++ b/vis.c
@@ -483,6 +483,8 @@ static void call(const Arg *arg);
 static void window(const Arg *arg);
 /* quit editor, discard all changes */
 static void quit(const Arg *arg);
+/* reindent current line */
+static void reindent_line(const Arg *arg);
 
 /** commands to enter at the ':'-prompt */
 /* set various runtime options */
@@ -709,6 +711,16 @@ static void do_reindent_line(Text *text, size_t line_begin, size_t *cursor) {
 	size_t new_start = vis->insert_indent(text, line_begin, false);
 	if (*cursor >= prev_start)
 		*cursor = *cursor - prev_start + new_start;
+}
+
+static void reindent_line(const Arg *arg) {
+	if (vis->insert_indent == NULL)
+		return;
+	size_t cursor = window_cursor_get(vis->win->win);
+	size_t line_begin = text_line_begin(vis->win->text, cursor);
+	do_reindent_line(vis->win->text, line_begin, &cursor);
+	window_cursor_to(vis->win->win, cursor);
+	editor_draw(vis);
 }
 
 static void op_reindent(OperatorContext *c) {


### PR DESCRIPTION
Putting this up for an early review (and I also fear that I won't find the time to work on this any more in the next weeks). This imitates vims cindent mode without having any options. What it does do:
- Add a hook to reindent the current line on CTRL+F
- Add the = command to reindent a visual block
- If the previous line ended in { indent
- Lines starting with # or which just contain spaces (but are not newly created) are not indentet
- Lines beginning with } are indented like the line that contained the matching {
- Lines ending in : (labels, case labels) are indentet like the line with the opening { of the current block (this is usually 1 indentation level less)
- Comment rules: If the previous line begins with "/*" or " *" then let the current line begin with " *" (for newly created lines)

This already does a fairly good job in many situations but it lacks some things that vim can do:
- Indent if the previous line started with "if", "while", "do" (for the cases when no {} block was used)
- Indent when the previous line did not end in ;, { or }  -  for broken long lines
- Maybe add a mode to indent unclosed ( ) braces to the level where the brace opened.
