### PR TITLE
Prevent black flicker on load

### DIFF
--- a/ui-curses.c
+++ b/ui-curses.c
@@ -532,6 +532,7 @@ Ui *ui_curses_new(void) {
 	if (!newterm(term, stderr, stdin))
 		return NULL;
 	start_color();
+	use_default_colors();
 	raw();
 	noecho();
 	keypad(stdscr, TRUE);


### PR DESCRIPTION
`use_default_colors()` needs to be called before the first `refresh()` call to prevent a black flicker when vis first loads. This is because ncurses loads with a black background by default.