### PR TITLE
Use $(MAKE) instead of directly calling `make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ vis: config.h config.mk *.c *.h
 	@${CC} ${CFLAGS} *.c ${LDFLAGS} -o $@
 
 debug: clean
-	@make CFLAGS='${DEBUG_CFLAGS}'
+	@$(MAKE) CFLAGS='${DEBUG_CFLAGS}'
 
 clean:
 	@echo cleaning


### PR DESCRIPTION
This fixes `make debug` on OpenBSD (and possibly other systems) where
/usr/bin/make isn't GNU make.