### PR TITLE
Undo tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,17 +135,22 @@ As illustrated above, each change to the text is recorded by an old and
 a new span. An action consists of multiple changes which logically belong
 to each other and should thus also be reverted together. For example
 a search and replace operation is one action with possibly many changes
-all over the text. Actions are saved in a tree structure.
+all over the text.
 
-A state of the text can be marked by means of a snapshotting operation.
-Snapshotting saves a new node to the history tree and creates a fresh Action
-to which future changes will be appended until the next snapshot.
-The undo/redo functionality operates on such marked states and switches
-between them by traversing adjacent nodes in the tree.
+The text states can be marked by means of a snapshotting operation.
+Snapshotting saves a new node to the history graph and creates a fresh
+Action to which future changes will be appended until the next snapshot.
 
-Undo and Redo move the state of the document up and down on a single branch
-of the history tree, but other branches can be accessed with the Earlier
-and Later commands, which iterate through snapshotted states chronologically.
+Actions make up the nodes of a connected digraph, each representing a state
+of the file at some time during the current editing session. The edges of the
+digraph represent state transitions that are supported by the editor. The edges
+are implemented as four Action pointers (`prev`, `next`, `earlier`, and `later`).
+
+The editor operations that execute the four aforementioned transitions
+are `undo`, `redo`,`earlier`, and `later`, respectively. Undo and
+redo behave in the traditional manner, changing the state one Action
+at a time. Earlier and later, however, traverse the states in chronological
+order, which may occasionally involve undoing and redoing many Actions at once.
 
 Properties
 ----------

--- a/text.c
+++ b/text.c
@@ -99,6 +99,7 @@ struct Action {
 	Action *earlier;        /* the previous Action, chronologically */
 	Action *later;          /* the next Action, chronologically */
 	time_t time;            /* when the first change of this action was performed */
+	size_t seq;             /* a unique, strictly increasing identifier */
 };
 
 typedef struct {
@@ -342,6 +343,13 @@ static Action *action_alloc(Text *txt) {
 		return NULL;
 	new->time = time(NULL);
 	txt->current_action = new;
+
+	/* set sequence number */
+	if (!txt->last_action)
+		new->seq = 0;
+	else
+		new->seq = txt->last_action->seq + 1;
+
 	/* set earlier, later pointers */
 	if (txt->last_action)
 		txt->last_action->later = new;

--- a/text.c
+++ b/text.c
@@ -633,13 +633,13 @@ static size_t history_traverse_to(Text *txt, Action *a) {
 		return pos;
 	bool changed = history_change_branch(a);
 	if (!changed) {
-		if (a->time == txt->history->time) {
+		if (a->seq == txt->history->seq) {
 			return txt->lines.pos;
-		} else if (a->time > txt->history->time) {
+		} else if (a->seq > txt->history->seq) {
 			while (txt->history != a)
 				pos = text_redo(txt);
 			return pos;
-		} else if (a->time < txt->history->time) {
+		} else if (a->seq < txt->history->seq) {
 			while (txt->history != a)
 				pos = text_undo(txt);
 			return pos;


### PR DESCRIPTION
Realized I completely forgot to put in a pull request after finishing this back in May.

This adds history-tree functionality to the editor. Undo and redo work as before, and there are new :earlier and :later commands (shortcuts g- and g+, respectively) which move chronologically through changes.