### PR TITLE
Optional vi-like cursor behavior when leaving insert mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,11 @@ and their current support in vis.
        use syntax definition given (e.g. "c") or disable syntax
        highlighting if no such definition exists (e.g :set syntax off)
 
+     vicursor (yes|no)
+
+       whether cursor steps back a column after leaving insert mode,
+       as in nvi/elvis/vim
+
   Each command can be prefixed with a range made up of a start and
   an end position as in start,end. Valid position specifiers are:
 

--- a/config.def.h
+++ b/config.def.h
@@ -566,6 +566,11 @@ static KeyBinding vis_mode_insert[] = {
 static void vis_mode_insert_leave(Mode *old) {
 	/* make sure we can recover the current state after an editing operation */
 	text_snapshot(vis->win->file->text);
+
+	/* If vicursor is enabled, move the cursor back one column unless already on
+	 * the first one */
+	if (vis->vicursor && view_cursor_getpos(vis->win->view).col != 1)
+		movement(&(const Arg){ .i = MOVE_CHAR_PREV });
 }
 
 static void vis_mode_insert_idle(void) {

--- a/editor.h
+++ b/editor.h
@@ -235,6 +235,7 @@ struct Editor {
 	int tabwidth;                     /* how many spaces should be used to display a tab */
 	bool expandtab;                   /* whether typed tabs should be converted to spaces */
 	bool autoindent;                  /* whether indentation should be copied from previous line on newline */
+	bool vicursor;                    /* whether cursor behaves like in nvi/elvis/vim after leaving insert mode */
 	Map *cmds;                        /* ":"-commands, used for unique prefix queries */
 	Map *options;                     /* ":set"-options */
 	Buffer buffer_repeat;             /* holds data to repeat last insertion/replacement */

--- a/vis.c
+++ b/vis.c
@@ -1329,6 +1329,7 @@ static bool cmd_set(Filerange *range, enum CmdOpt cmdopt, const char *argv[]) {
 		OPTION_SYNTAX,
 		OPTION_NUMBER,
 		OPTION_NUMBER_RELATIVE,
+		OPTION_VICURSOR,
 	};
 
 	/* definitions have to be in the same order as the enum above */
@@ -1339,6 +1340,7 @@ static bool cmd_set(Filerange *range, enum CmdOpt cmdopt, const char *argv[]) {
 		[OPTION_SYNTAX]          = { { "syntax"                 }, OPTION_TYPE_STRING, true },
 		[OPTION_NUMBER]          = { { "numbers", "nu"          }, OPTION_TYPE_BOOL   },
 		[OPTION_NUMBER_RELATIVE] = { { "relativenumbers", "rnu" }, OPTION_TYPE_BOOL   },
+		[OPTION_VICURSOR]        = { { "vicursor"               }, OPTION_TYPE_BOOL   },
 	};
 
 	if (!vis->options) {
@@ -1443,6 +1445,9 @@ static bool cmd_set(Filerange *range, enum CmdOpt cmdopt, const char *argv[]) {
 	case OPTION_NUMBER_RELATIVE:
 		editor_window_options(vis->win, arg.b ? UI_OPTION_LINE_NUMBERS_RELATIVE :
 			UI_OPTION_LINE_NUMBERS_NONE);
+		break;
+	case OPTION_VICURSOR:
+		vis->vicursor = arg.b;
 		break;
 	}
 


### PR DESCRIPTION
This addresses #42 in a non-intrusive way. When the `vicursor` option is set, the cursor will move one column to the left upon exiting insert mode. Since newlines are addressable and appear before the first column of the next line, the exception to this behavior is when insert mode is left while the cursor is on the first column of a line.

 I am not sure that putting this functionality in config.def.h is the right approach, but it works for me.