### PR TITLE
Fixed $VIS_THEME warning message

### DIFF
--- a/ui-curses.c
+++ b/ui-curses.c
@@ -1006,7 +1006,7 @@ static bool ui_init(Ui *ui, Vis *vis) {
 	} else {
 		theme = COLORS <= 16 ? "default-16" : "default-256";
 		if (!vis_theme_load(vis, theme))
-			vis_info_show(vis, "Warning: failed to load theme `%s' set $VIS_PATH", theme);
+			vis_info_show(vis, "Warning: failed to load theme `%s' set $VIS_THEME", theme);
 	}
 	return true;
 }


### PR DESCRIPTION
If the `$VIS_THEME` environment variable doesn't exist, the existing warning incorrectly indicates that you should set `$VIS_PATH`. This changes the warning to suggest setting `$VIS_THEME`.