### PR TITLE
gitignore: Fix pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-config.h
+/config.h
 *.swo
 *.swp
 *.o
-./vis
-dependency
+/vis
+/dependency


### PR DESCRIPTION
From `man gitignore`:

```
o   A leading slash matches the beginning of the pathname. For example,
   "/*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".
```