### PR TITLE
calc tab spaces for multiple cursors.

### DIFF
--- a/vis-core.h
+++ b/vis-core.h
@@ -169,6 +169,7 @@ extern Movement moves[VIS_MOVE_INVALID];
 extern Operator ops[VIS_OP_INVALID];
 
 const char *expandtab(Vis *vis);
+const char *expandtab_cursor(Vis *vis, Cursor *c);
 
 void macro_operator_stop(Vis *vis);
 void macro_operator_record(Vis *vis);

--- a/vis.c
+++ b/vis.c
@@ -60,15 +60,11 @@ const char *expandtab_cursor(Vis *vis, Cursor *c) {
     if (!vis->expandtab)
         return "\t";
 
-    const int MAX_TABWIDTH = 8;
-    int tabwidth = MIN(vis->tabwidth, MAX_TABWIDTH);
-    size_t pos = view_cursors_pos(c);
-    int w=tabwidth;
-    while(w<=pos) 
-        w += tabwidth;
-    tabwidth = w - pos;
-
     static char spaces[9];
+    int tabwidth = MIN(vis->tabwidth, LENGTH(spaces) - 1);
+    size_t pos = view_cursors_pos(c);
+    tabwidth = tabwidth - (pos % tabwidth);
+
     for (int i = 0; i < tabwidth; i++)
         spaces[i] = ' ';
     spaces[tabwidth] = '\0';


### PR DESCRIPTION
Fix for #144 
I created a new `expandtab_cursor` function since `op_shift_right` still uses the old version.
Not sure this is right though.. Still need some testing .. 
Sometimes one char is off.. hmm..