### PR TITLE
regex match word fix for * and #

### DIFF
--- a/vis-motions.c
+++ b/vis-motions.c
@@ -16,9 +16,9 @@ static bool search_word(Vis *vis, Text *txt, size_t pos) {
 	char *buf = text_bytes_alloc0(txt, word.start, text_range_size(&word));
 	if (!buf)
 		return false;
-	snprintf(expr, sizeof(expr), "\\<%s\\>", buf);
+	snprintf(expr, sizeof(expr), "\\(%s\\)", buf);
 	free(buf);
-	return text_regex_compile(vis->search_pattern, expr, REG_EXTENDED) == 0;
+	return text_regex_compile(vis->search_pattern, expr, REG_BASIC) == 0;
 }
 
 /** motion implementations */


### PR DESCRIPTION
This fixes the problem #152 where i could not match words by `*`and `#` on OSX. 
Could you test if this works on linux as well?