### PR TITLE
using posix compliant word-boundaries

### DIFF
--- a/vis-motions.c
+++ b/vis-motions.c
@@ -16,7 +16,7 @@ static bool search_word(Vis *vis, Text *txt, size_t pos) {
 	char *buf = text_bytes_alloc0(txt, word.start, text_range_size(&word));
 	if (!buf)
 		return false;
-	snprintf(expr, sizeof(expr), "\\<%s\\>", buf);
+	snprintf(expr, sizeof(expr), "[[:<:]]%s[[:>:]]", buf);
 	free(buf);
 	return text_regex_compile(vis->search_pattern, expr, REG_EXTENDED) == 0;
 }


### PR DESCRIPTION
Added a fix for POSIX compliant word boundaries. Should fix #152.
Ref (bottom of page):
http://www.regular-expressions.info/wordboundaries.html