### PR TITLE
langmap command implementation

### DIFF
--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -1082,7 +1082,6 @@ static bool cmd_langmap(Vis *vis, Filerange *range, enum CmdOpt opt, const char 
 	/* Two separated counters for latin and nonlatin strings required due to unicode chars*/
 	size_t latin_i = 0;
 	size_t nonlatin_i = 0;
-	size_t nonlatin_size = strlen(nonlatin);
 	char latin_key[2];
 	latin_key[1] = '\0';
 	for (latin_i = 0; latin_i < strlen(latin); latin_i++) {
@@ -1095,6 +1094,10 @@ static bool cmd_langmap(Vis *vis, Filerange *range, enum CmdOpt opt, const char 
 		size_t char_size = 0;
 		if (nonlatin[nonlatin_i] & UNICODE_MULTIBYTE) {
 			char_size = 3 - (~nonlatin[nonlatin_i] >> 4);
+			if (char_size > 3) {
+				vis_info_show(vis, "bad unicode character encountered");
+				return false;
+			}
 			char_size += (!char_size);
 		}
 		char_size += 1;

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -1104,8 +1104,10 @@ static bool cmd_langmap(Vis *vis, Filerange *range, enum CmdOpt opt, const char 
 		memcpy(nonlatin_key, nonlatin+nonlatin_i, char_size);
 		nonlatin_i += char_size;
 		nonlatin_key[char_size] = '\0';
-		mapped &= bind_key(vis, VIS_MODE_NORMAL, nonlatin_key, latin_key, false, force) &&	
-		         bind_key(vis, VIS_MODE_VISUAL, nonlatin_key, latin_key, false, force);
+		mapped &= bind_key(vis, VIS_MODE_NORMAL, nonlatin_key, latin_key, false, force) &&
+		          bind_key(vis, VIS_MODE_OPERATOR_PENDING, nonlatin_key, latin_key, false, force) &&
+		          bind_key(vis, VIS_MODE_VISUAL_LINE, nonlatin_key, latin_key, false, force) &&
+		          bind_key(vis, VIS_MODE_VISUAL, nonlatin_key, latin_key, false, force);
 	}
 	return mapped;
 }

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -1092,7 +1092,7 @@ static bool cmd_langmap(Vis *vis, Filerange *range, enum CmdOpt opt, const char 
 		}
 		size_t char_size = 1;
 		char char_head = nonlatin[nonlatin_i];
-		if (ISUTF8(char_head)) {
+		if ((!ISASCII(char_head)) && ISUTF8(char_head)) {
 			bool third_byte = char_head & (1 << 5);
 			bool fourth_byte = third_byte && (char_head & (1 << 4));
 			char_size = 2 + third_byte + fourth_byte;

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -1115,7 +1115,7 @@ static bool cmd_map(Vis *vis, Filerange *range, enum CmdOpt opt, const char *arg
 	enum VisMode mode = str2vismode(argv[1]);
 	const char *lhs = argv[2];
 	const char *rhs = argv[3];
-	char *key;
+	char *key = 0;
 	
 	if (mode == VIS_MODE_INVALID || !lhs || !rhs) {
 		vis_info_show(vis, "usage: map mode lhs rhs\n");
@@ -1136,11 +1136,8 @@ static bool cmd_map(Vis *vis, Filerange *range, enum CmdOpt opt, const char *arg
 				key[end - start] = '\0';
 			}
 		}
-		else {
-			return false;
-		}
 	}
-	else {
+	if (!key) {
 		key = strdup(rhs);
 	}
 	bool result = bind_key(vis, mode, lhs, key, local, opt & CMD_OPT_FORCE);

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -1133,6 +1133,9 @@ static bool cmd_map(Vis *vis, Filerange *range, enum CmdOpt opt, const char *arg
 				key[end - start] = '\0';
 			}
 		}
+		else {
+			return false;
+		}
 	}
 	else {
 		key = strdup(rhs);


### PR DESCRIPTION
Refered to  #161
I've decided to implement some analogue of vim's `:set langmap` command.
The implementation is based on [cmd_map](https://github.com/martanne/vis/blob/master/vis-cmds.c#L1033)'s code. The code shared between [cmd_map](https://github.com/xomachine/vis/blob/master/vis-cmds.c#L1110) and new [cmd_langmap](https://github.com/xomachine/vis/blob/master/vis-cmds.c#L1071) functions was separated in [bind_key](https://github.com/xomachine/vis/blob/master/vis-cmds.c#L1036) function.

Any criticism is appreciated.

Usage:
`:langmap <latin keys> <non-latin keys>`

Example:
`:langmap qwertyuiop[] йцукенгшщзхъ`

PS: I've tried to check my code for memory leaks using valgrind, but encountered  a leak in original [cmd_map](https://github.com/martanne/vis/blob/master/vis-cmds.c#L1033) function. Valgrind complains on [this calloc call](https://github.com/martanne/vis/blob/master/vis-cmds.c#L1044).