### PR TITLE
langmap command implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Operators can be forced to work line wise by specifying `V`.
     :unmap        remove a global key mapping
     :map-window   add a window local key mapping
     :unmap-window remove a window local key mapping
+    :langmap      set key equivalents for layout specific key mappings
     :!            filter range through external command
     :|            pipe range to external command and display output in a new window
     :set          set the options below
@@ -390,6 +391,22 @@ Unmapping works as follows:
     :unmap <lhs>
 
 The commands suffixed with `-window` only affect the currently active window.
+
+### Layout Specific Key Bindings
+
+Vis allows user to set key equivalents for non-latin keyboard layout to avoid
+often layout switching while editing non-latin text like vim's `:set langmap` does.
+For example, just type something like:
+
+    :langmap hjkl ролд
+
+to add support of movement keys in Russian layout.
+In general, syntax of `:langmap` command can be described as
+
+    :langmap <sequence of keys in latin layout> <sequence of equivalent keys in your layout>
+
+If one of key sequences is shorter than other, the rest of the longest sequence
+will be discarded.
 
 ### Tab <-> Space conversion and Line endings \n vs \r\n
 

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -1068,7 +1068,6 @@ static bool cmd_langmap(Vis *vis, Filerange *range, enum CmdOpt opt, const char 
 		nonlatin_key[char_size] = '\0';
 		mapped &= vis_keymap_add(vis, nonlatin_key, strdup(latin_key));
 	}
-	if (mapped) vis_info_show(vis, "Success!");
 	return mapped;
 }
 

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -89,6 +89,8 @@ static bool cmd_help(Vis*, Filerange*, enum CmdOpt, const char *argv[]);
 /* change runtime key bindings */
 static bool cmd_map(Vis*, Filerange*, enum CmdOpt, const char *argv[]);
 static bool cmd_unmap(Vis*, Filerange*, enum CmdOpt, const char *argv[]);
+/* set language specific key bindings */
+static bool cmd_langmap(Vis*, Filerange*, enum CmdOpt, const char *argv[]);
 
 /* command recognized at the ':'-prompt. commands are found using a unique
  * prefix match. that is if a command should be available under an abbreviation
@@ -103,6 +105,7 @@ static const Command cmds[] = {
 	{ { "map-window",              }, cmd_map,           CMD_OPT_FORCE|CMD_OPT_ARGS },
 	{ { "unmap",                   }, cmd_unmap,         CMD_OPT_ARGS               },
 	{ { "unmap-window",            }, cmd_unmap,         CMD_OPT_ARGS               },
+	{ { "langmap",                 }, cmd_langmap,       CMD_OPT_FORCE|CMD_OPT_ARGS },
 	{ { "new"                      }, cmd_new,           CMD_OPT_NONE               },
 	{ { "open"                     }, cmd_open,          CMD_OPT_NONE               },
 	{ { "qall"                     }, cmd_qall,          CMD_OPT_FORCE              },
@@ -1028,6 +1031,45 @@ static enum VisMode str2vismode(const char *mode) {
 			return i;
 	}
 	return VIS_MODE_INVALID;
+}
+
+static bool cmd_langmap(Vis *vis, Filerange *range, enum CmdOpt opt, const char *argv[]) {
+	const char *latin = argv[1];
+	const char *nonlatin = argv[2];
+	bool mapped = true;
+
+	if ( !latin || !nonlatin) {
+		vis_info_show(vis, "usage: langmap <latin keys> <non-latin keys>");
+		return false;
+	}
+	/* Two separated counters for latin and nonlatin strings required due to unicode chars*/
+	size_t latin_i = 0;
+	size_t nonlatin_i = 0;
+	size_t nonlatin_size = strlen(nonlatin);
+	size_t latin_size = strlen(latin);
+	char latin_key[2];
+	latin_key[1] = '\0';
+	for (latin_i = 0; (latin_i < latin_size) && (nonlatin_i < nonlatin_size); latin_i++) {
+		char nonlatin_key[5]; /*5 bytes should be enough for unicode char with \0 */
+		latin_key[0] = latin[latin_i];
+		if (!ISASCII(latin_key[0])) {
+			vis_info_show(vis, "no non-latin characters allowed in first argument");
+			return false;
+		}
+		size_t char_size = 1;
+		char leading_byte = nonlatin[nonlatin_i];
+		if (ISUTF8(leading_byte) && !ISASCII(leading_byte)) { /*0b11xxxxxx*/
+			bool third_byte = leading_byte & (1 << 5); /*0b1110xxxx*/
+			bool fourth_byte = third_byte && (leading_byte & (1 << 4)); /*0b1111xxxx*/
+			char_size = 2 + third_byte + fourth_byte;
+		}
+		memcpy(nonlatin_key, nonlatin+nonlatin_i, char_size);
+		nonlatin_i += char_size;
+		nonlatin_key[char_size] = '\0';
+		mapped &= vis_keymap_add(vis, nonlatin_key, strdup(latin_key));
+	}
+	if (mapped) vis_info_show(vis, "Success!");
+	return mapped;
 }
 
 static bool cmd_map(Vis *vis, Filerange *range, enum CmdOpt opt, const char *argv[]) {


### PR DESCRIPTION
Refered to #161 and #174

It's realization of `:langmap` command adapted for [vis->keymap](https://github.com/xomachine/vis/blob/master/vis-core.h#L158) filling with short description in README.md.
