### PR TITLE
Warnings

### DIFF
--- a/main.c
+++ b/main.c
@@ -34,8 +34,6 @@ static const char *mark_set(Vis*, const char *keys, const Arg *arg);
 static const char *openline(Vis*, const char *keys, const Arg *arg);
 /* join lines from current cursor position to movement indicated by arg */
 static const char *join(Vis*, const char *keys, const Arg *arg);
-/* execute arg->s as if it was typed on command prompt */
-static const char *cmd(Vis*, const char *keys, const Arg *arg);
 /* perform last action i.e. action_prev again */
 static const char *repeat(Vis*, const char *keys, const Arg *arg);
 /* replace character at cursor with one from keys */
@@ -1595,11 +1593,6 @@ static const char *insert_verbatim(Vis *vis, const char *keys, const Arg *arg) {
 
 	if (len > 0)
 		vis_insert_key(vis, data, len);
-	return keys;
-}
-
-static const char *cmd(Vis *vis, const char *keys, const Arg *arg) {
-	vis_cmd(vis, arg->s);
 	return keys;
 }
 

--- a/view.c
+++ b/view.c
@@ -635,8 +635,8 @@ void view_update(View *view) {
 
 	if (view->colorcolumn > 0) {
 		size_t lineno = 0;
-		int line_cols; /* Track the number of columns we've passed on each line */
-		bool line_cc_set; /* Has the colorcolumn attribute been set for this line yet */
+		int line_cols = 0; /* Track the number of columns we've passed on each line */
+		bool line_cc_set = false; /* Has the colorcolumn attribute been set for this line yet */
 
 		for (Line *l = view->topline; l; l = l->next) {
 			if (l->lineno != lineno) {


### PR DESCRIPTION
fix compiler warnings:

‘cmd’ defined but not used
‘line_cc_set’ may be used uninitialized in this function
‘line_cols’ may be used uninitialized in this function