### PR TITLE
configure: make vis depend on config.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ all: vis
 config.h:
 	cp config.def.h config.h
 
-vis: config.h *.c *.h
+vis: config.h config.mk *.c *.h
 	${CC} ${CFLAGS} ${CFLAGS_VIS} *.c ${LDFLAGS} ${LDFLAGS_VIS} -o $@
 
 debug: clean


### PR DESCRIPTION
We want vis to be rebuilt when configuration changes, so make vis depend
on config.mk.