### PR TITLE
Remove bashisms from configure script.

### DIFF
--- a/configure
+++ b/configure
@@ -204,9 +204,9 @@ LDFLAGS_STD="-lc"
 OS=$(uname)
 
 case "$OS" in
-*BSD)   CFLAGS_STD+=-D_DARWIN_C_SOURCE ;;
-Darwin) CFLAGS_STD+=-D_BSD_SOURCE ;;
-AIX)    CFLAGS_STD+=-D_ALL_SOURCE ;;
+*BSD)   CFLAGS_STD="$CFLAGS_STD -D_DARWIN_C_SOURCE" ;;
+Darwin) CFLAGS_STD="$CFLAGS_STD -D_BSD_SOURCE" ;;
+AIX)    CFLAGS_STD="$CFLAGS_STD -D_ALL_SOURCE" ;;
 esac
 
 tryflag CFLAGS_AUTO -pipe
@@ -349,7 +349,10 @@ EOF
 	done
 
 	test "$lua" = "yes" -a $CONFIG_LUA -ne 1 && fail "$0: cannot find liblua"
-	test $CONFIG_LUA -eq 1 && CFLAGS_LUA+=" -DLUA_COMPAT_5_1 -DLUA_COMPAT_5_2 -DLUA_COMPAT_ALL"
+
+	if test $CONFIG_LUA -eq 1; then
+		CFLAGS_LUA="$CFLAGS_LUA -DLUA_COMPAT_5_1 -DLUA_COMPAT_5_2 -DLUA_COMPAT_ALL"
+	fi
 fi
 
 CONFIG_ACL=0


### PR DESCRIPTION
The `+=` assignment operator is not required to be supported by a POSIX shell.