### PR TITLE
Copy to system clipboard when running on Cygwin.

### DIFF
--- a/vis-copy
+++ b/vis-copy
@@ -4,6 +4,8 @@ if [ ! -z "$DISPLAY" ]; then
 	exec xsel -ib
 elif type pbcopy >/dev/null 2>&1; then
 	exec pbcopy
+elif [ -c /dev/clipboard ]; then
+	exec cat >/dev/clipboard
 else
 	echo "System clipboard not supported" 1>&2
 	exit 1

--- a/vis-paste
+++ b/vis-paste
@@ -4,6 +4,8 @@ if [ ! -z "$DISPLAY" ]; then
 	exec xsel -ob
 elif type pbpaste >/dev/null 2>&1; then
 	exec pbpaste
+elif [ -c /dev/clipboard ]; then
+	exec cat /dev/clipboard
 else
 	echo "System clipboard not supported" 1>&2
 	exit 1


### PR DESCRIPTION
Updated `vis-copy` and `vis-paste` to use `/dev/clipboard` for copy/paste to/from the system clipboard when running on Cygwin.