### PR TITLE
Use default instead of black, white in dark-16 theme

### DIFF
--- a/lexers/themes/dark-16.lua
+++ b/lexers/themes/dark-16.lua
@@ -1,8 +1,8 @@
 -- Eight-color scheme
 local lexers = vis.lexers
 -- dark
-lexers.STYLE_DEFAULT = 'back:black,fore:white'
-lexers.STYLE_NOTHING = 'back:black'
+lexers.STYLE_DEFAULT = 'back:default,fore:default'
+lexers.STYLE_NOTHING = 'back:default'
 lexers.STYLE_CLASS = 'fore:yellow'
 lexers.STYLE_COMMENT = 'fore:blue'
 lexers.STYLE_CONSTANT = 'fore:cyan'
@@ -23,7 +23,7 @@ lexers.STYLE_WHITESPACE = ''
 lexers.STYLE_EMBEDDED = 'back:blue'
 lexers.STYLE_IDENTIFIER = 'fore:white'
 
-lexers.STYLE_LINENUMBER = 'fore:white'
+lexers.STYLE_LINENUMBER = 'fore:default'
 lexers.STYLE_CURSOR = 'reverse'
 lexers.STYLE_CURSOR_PRIMARY = lexers.STYLE_CURSOR..',blink'
 lexers.STYLE_CURSOR_LINE = 'back:white'


### PR DESCRIPTION
This is probably a matter of taste - if not a source of anguish! - so feel free to ignore this PR.

I've tested `back:default` and `fore:default`, instead of `back:black` and `fore:white` in both `xterm` and `urxvt` and it 'just works' or, at least, works the way that I would expect it to. (I'm not sure how much of it 'working' is dependent on my local set-up `.Xresources`, etc., though.)

Here's the default `dark-16.lua`...

![screen shot 2016-04-08 at 16 49 30](https://cloud.githubusercontent.com/assets/1852005/14389348/2b5d2e14-fdaa-11e5-8c6d-2e2914c89b72.png)

And my local changes, as proposed here...

![screen shot 2016-04-08 at 16 49 52](https://cloud.githubusercontent.com/assets/1852005/14389372/427469a0-fdaa-11e5-8d1f-e6d7cead495c.png)

