### PR TITLE
implement the vim-like 'gq' operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ supported features.
     d   (delete)
     !   (filter)
     =   (format using fmt(1))
+    gq  (wrap text)
     gu  (make lowercase)
     gU  (make uppercase)
     J   (join)

--- a/config.def.h
+++ b/config.def.h
@@ -158,6 +158,7 @@ static const KeyBinding bindings_operators[] = {
 	{ "g~",                 ACTION(OPERATOR_CASE_SWAP)                  },
 	{ "gp",                 ACTION(PUT_AFTER_END)                       },
 	{ "gP",                 ACTION(PUT_BEFORE_END)                      },
+	{ "gq",                 ACTION(OPERATOR_WRAP_TEXT)                  },
 	{ "gu",                 ACTION(OPERATOR_CASE_LOWER)                 },
 	{ "gU",                 ACTION(OPERATOR_CASE_UPPER)                 },
 	{ "p",                  ACTION(PUT_AFTER)                           },

--- a/main.c
+++ b/main.c
@@ -212,6 +212,7 @@ enum {
 	VIS_ACTION_OPERATOR_YANK,
 	VIS_ACTION_OPERATOR_SHIFT_LEFT,
 	VIS_ACTION_OPERATOR_SHIFT_RIGHT,
+	VIS_ACTION_OPERATOR_WRAP_TEXT,
 	VIS_ACTION_OPERATOR_CASE_LOWER,
 	VIS_ACTION_OPERATOR_CASE_UPPER,
 	VIS_ACTION_OPERATOR_CASE_SWAP,
@@ -729,6 +730,11 @@ static const KeyAction vis_action[] = {
 		"vis-operator-shift-right",
 		"Shift right operator",
 		operator, { .i = VIS_OP_SHIFT_RIGHT }
+	},
+	[VIS_ACTION_OPERATOR_WRAP_TEXT] = {
+		"vis-operator-wrap-text",
+		"Text wrap operator",
+		operator, { .i = VIS_OP_WRAP_TEXT }
 	},
 	[VIS_ACTION_OPERATOR_CASE_LOWER] = {
 		"vis-operator-case-lower",

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -12,6 +12,12 @@ static void tabwidth_set(Vis *vis, int tabwidth) {
 	vis->tabwidth = tabwidth;
 }
 
+static void textwidth_set(Vis *vis, int textwidth) {
+	if (textwidth < 0)
+		return;
+	vis->textwidth = textwidth;
+}
+
 /* parse human-readable boolean value in s. If successful, store the result in
  * outval and return true. Else return false and leave outval alone. */
 static bool parse_bool(const char *s, bool *outval) {
@@ -47,6 +53,7 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Cursor
 		OPTION_AUTOINDENT,
 		OPTION_EXPANDTAB,
 		OPTION_TABWIDTH,
+		OPTION_TEXTWIDTH,
 		OPTION_SYNTAX,
 		OPTION_SHOW,
 		OPTION_NUMBER,
@@ -61,6 +68,7 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Cursor
 		[OPTION_AUTOINDENT]      = { { "autoindent", "ai"       }, OPTION_TYPE_BOOL   },
 		[OPTION_EXPANDTAB]       = { { "expandtab", "et"        }, OPTION_TYPE_BOOL   },
 		[OPTION_TABWIDTH]        = { { "tabwidth", "tw"         }, OPTION_TYPE_NUMBER },
+		[OPTION_TEXTWIDTH]       = { { "textwidth"              }, OPTION_TYPE_NUMBER },
 		[OPTION_SYNTAX]          = { { "syntax"                 }, OPTION_TYPE_STRING, true },
 		[OPTION_SHOW]            = { { "show"                   }, OPTION_TYPE_STRING },
 		[OPTION_NUMBER]          = { { "numbers", "nu"          }, OPTION_TYPE_BOOL   },
@@ -148,6 +156,9 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Cursor
 		break;
 	case OPTION_TABWIDTH:
 		tabwidth_set(vis, arg.i);
+		break;
+	case OPTION_TEXTWIDTH:
+		textwidth_set(vis, arg.i);
 		break;
 	case OPTION_SYNTAX:
 		if (!argv[2]) {

--- a/vis-core.h
+++ b/vis-core.h
@@ -149,6 +149,7 @@ struct Vis {
 	char search_char[8];                 /* last used character to search for via 'f', 'F', 't', 'T' */
 	int last_totill;                     /* last to/till movement used for ';' and ',' */
 	int tabwidth;                        /* how many spaces should be used to display a tab */
+	int textwidth;                       /* line length before wrapping */
 	bool expandtab;                      /* whether typed tabs should be converted to spaces */
 	bool autoindent;                     /* whether indentation should be copied from previous line on newline */
 	Map *cmds;                           /* ":"-commands, used for unique prefix queries */

--- a/vis-operators.c
+++ b/vis-operators.c
@@ -197,14 +197,14 @@ static size_t op_wrap_text(Vis *vis, Text *txt, OperatorContext *c) {
 			if (break_pos == prev_pos) {
 				/* vis->textwidth is longer than this word, insert line break
 				 * immediately after this word */
-				break_pos = pos + 1;
+				break_pos = text_char_next(txt, pos);
 			} else {
 				/* found an appropriate line break point just before this word */
-				break_pos = break_pos - 1;
+				break_pos = text_char_prev(txt, break_pos);
 			}
 			text_delete(txt, break_pos, 1);
 			text_insert(txt, break_pos, "\n", 1);
-			pos = break_pos + 1;
+			pos = text_char_next(txt, break_pos);
 		}
 	} while (pos != prev_pos && pos < c->range.end);
 

--- a/vis.c
+++ b/vis.c
@@ -351,6 +351,7 @@ Vis *vis_new(Ui *ui, VisEvent *event) {
 	vis->ui = ui;
 	vis->ui->init(vis->ui, vis);
 	vis->tabwidth = 8;
+	vis->textwidth = 0;
 	vis->expandtab = false;
 	vis->registers[VIS_REG_BLACKHOLE].type = REGISTER_BLACKHOLE;
 	vis->registers[VIS_REG_CLIPBOARD].type = REGISTER_CLIPBOARD;

--- a/vis.h
+++ b/vis.h
@@ -159,6 +159,7 @@ enum VisOperator {
 	VIS_OP_CURSOR_SOL,
 	VIS_OP_CASE_SWAP,
 	VIS_OP_FILTER,
+	VIS_OP_WRAP_TEXT,
 	VIS_OP_INVALID, /* denotes the end of the "real" operators */
 	/* pseudo operators: keep them at the end to save space in array definition */
 	VIS_OP_CASE_LOWER,


### PR DESCRIPTION
This is used to line-wrap text based on the 'textwidth' option value.

Note that normally 'textwidth' would have the alias 'tw', but that's currently taken by 'tabwidth'... Might want to normalize 'tabwidth' to 'tabstop' to match vim's naming.

This hasn't undergone particularly extensive testing, aside from verifying that the line wrapping results matched vim's behavior for the cases I tried. I tested using visual line-selection with multiple paragraphs, single paragraph, etc. There are probably other cases I should try, but this works for the common usecases I have.