### PR TITLE
added link to new SMGL package for vis

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Or simply use one of the distribution provided packages:
 
  * [ArchLinux](http://www.archlinux.org/packages/?q=vis)
  * [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=vis)
+ * [Source Mage GNU/Linux](http://download.sourcemage.org/grimoire/codex/test/editors/vis)
  * [Void Linux](https://github.com/voidlinux/void-packages/tree/master/srcpkgs/vis)
  * [pkgsrc](http://pkgsrc.se/wip/vis-editor)
 


### PR DESCRIPTION
vis has been packaged for Source Mage GNU/Linux, one of the oldest Linux distros, aimed at high flexibility in customization, while building packages from source.