### PR TITLE
Support zenity alongside slmenu and dmenu

### DIFF
--- a/vis-open
+++ b/vis-open
@@ -4,6 +4,30 @@ PATTERN="."
 [ -z "$VIS_MENU" ] && VIS_MENU="slmenu"
 [ -z "$VIS_MENU_ARGS" ] && VIS_MENU_ARGS="-b"
 
+zenity_wrapper () {
+	local ARGS
+
+	while [ $# -gt 0 ]; do
+		case "$1" in
+		-p)
+			ARGS="$ARGS --text $2"
+			shift
+			shift
+			;;
+		-b)
+			# Not relevant for zenity
+			shift
+			;;
+		*)
+			echo "Unhandled option $1" >&2
+			exit 1
+			;;
+		esac
+	done
+
+	zenity --list --column Filename $ARGS 2>/dev/null
+}
+
 while [ $# -gt 0 ]; do
 	case "$1" in
 	-h|--help)
@@ -23,11 +47,15 @@ while [ $# -gt 0 ]; do
 done
 
 if ! type "$VIS_MENU" >/dev/null 2>&1; then
-	if [ ! -z "$DISPLAY" ] && type "dmenu" >/dev/null 2>&1; then
-		VIS_MENU="dmenu"
-	else
-		echo "Neither slmenu nor dmenu found" >&2
-		exit 1
+	if [ ! -z "$DISPLAY" ]; then
+		if type "dmenu" >/dev/null 2>&1; then
+			VIS_MENU="dmenu"
+		elif type "zenity" >/dev/null 2>&1; then
+			VIS_MENU="zenity_wrapper"
+		else
+			echo "No compatible menu helper found" >&2
+			exit 1
+		fi
 	fi
 fi
 


### PR DESCRIPTION
Because zenity has a slightly different command-line interface than `slmenu` or `dmenu`, `vis-open` now has a wrapper function that converts `slmenu`-style arguments to what zenity expects.

zenity is rather different in style from `slmenu` and `dmenu`, but it's much more likely to be available. Compare the Debian installation statistics for [zenity](https://qa.debian.org/popcon.php?package=zenity) versus [suckless-tools](https://qa.debian.org/popcon.php?package=suckless-tools) (the Debian package containinng `dmenu`). So far as I can tell, Debian doesn't even *have* a package for `slmenu`.

I considered also trying to add support for `dialog` or `whiptail`, but their interfaces are even more wildly different.