### PR TITLE
Added functionality to complete word

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -321,6 +321,7 @@ static const KeyBinding bindings_insert[] = {
 	{ "<C-i>",              ALIAS("<Tab>")                              },
 	{ "<C-j>",              ALIAS("<Enter>")                            },
 	{ "<C-m>",              ALIAS("<Enter>")                            },
+	{ "<C-n>",              ACTION(COMPLETE_WORD)                       },
 	{ "<C-o>",              ACTION(MODE_OPERATOR_PENDING)               },
 	{ "<C-r>",              ACTION(INSERT_REGISTER)                     },
 	{ "<C-t>",              ALIAS("<Escape>>>i")                        },

--- a/main.c
+++ b/main.c
@@ -40,6 +40,8 @@ static const char *join(Vis*, const char *keys, const Arg *arg);
 static const char *repeat(Vis*, const char *keys, const Arg *arg);
 /* replace character at cursor with one from keys */
 static const char *replace(Vis*, const char *keys, const Arg *arg);
+/* complete word by first match */
+static const char *complete_word(Vis*, const char *keys, const Arg *arg);
 /* create a new cursor on the previous (arg->i < 0) or next (arg->i > 0) line */
 static const char *cursors_new(Vis*, const char *keys, const Arg *arg);
 /* try to align all cursors on the same column */
@@ -248,6 +250,7 @@ enum {
 	VIS_ACTION_PUT_BEFORE,
 	VIS_ACTION_PUT_AFTER_END,
 	VIS_ACTION_PUT_BEFORE_END,
+	VIS_ACTION_COMPLETE_WORD,
 	VIS_ACTION_CURSOR_SELECT_WORD,
 	VIS_ACTION_CURSORS_NEW_LINE_ABOVE,
 	VIS_ACTION_CURSORS_NEW_LINE_ABOVE_FIRST,
@@ -914,6 +917,11 @@ static const KeyAction vis_action[] = {
 		"Put text before the cursor, place cursor after new text",
 		operator, { .i = VIS_OP_PUT_BEFORE_END }
 	},
+	[VIS_ACTION_COMPLETE_WORD] = {
+		"complete-word",
+		"Complete word by first match",
+		complete_word,
+	},
 	[VIS_ACTION_CURSOR_SELECT_WORD] = {
 		"cursors-select-word",
 		"Select word under cursor",
@@ -1261,6 +1269,80 @@ static const char *suspend(Vis *vis, const char *keys, const Arg *arg) {
 
 static const char *repeat(Vis *vis, const char *keys, const Arg *arg) {
 	vis_repeat(vis);
+	return keys;
+}
+
+static size_t find_next_epos(Text *txt, size_t pos, const char *s) {
+	if (!s)
+		return EPOS;
+	size_t len = strlen(s), matched = 0;
+	Iterator it = text_iterator_get(txt, pos), sit;
+	for (char c; matched < len && text_iterator_byte_get(&it, &c); ) {
+		if (c == s[matched]) {
+			if (matched == 0)
+				sit = it;
+			matched++;
+		} else if (matched > 0) {
+			it = sit;
+			matched = 0;
+		}
+		text_iterator_byte_next(&it, NULL);
+	}
+	return matched == len ? it.pos - len : EPOS;
+}
+
+static const char *complete_word(Vis *vis, const char *keys, const Arg *arg) {
+	Text *txt = vis_text(vis);
+	View *view = vis_view(vis);
+	Cursor *cursor = view_cursors_primary_get(view);
+	// get word to look for
+	Filerange word = text_object_word(txt, view_cursors_pos(cursor) - 1);
+	if (!text_range_valid(&word))
+		return keys;
+	size_t word_len = text_range_size(&word);
+	char *buf = text_bytes_alloc0(txt, word.start, word_len);
+	if (!buf)
+		return keys;
+	// look for match, except if on cursor
+	Filepos p = 0;
+	Filepos p_next = find_next_epos(txt, p, buf);
+	while(p_next != EPOS) {
+		// we have a match, but it might be on a cursor
+		bool on_cursor = false;
+		for (Cursor *c = view_cursors(view); c; c = view_cursors_next(c)) {
+			Filerange c_word = text_object_word(txt, view_cursors_pos(c) - 1);
+			if(c_word.start == p_next) {
+				// it is on a cursor, look for the next match
+				p += text_range_size(&c_word);
+				p_next = find_next_epos(txt, p, buf);
+				on_cursor = true;
+				break;
+			}
+		}
+		if(!on_cursor)
+			break;
+	}
+	free(buf);
+	if(p == EPOS)
+		return keys;
+	// get remaining word
+	Filerange next = text_object_word(txt, p_next);
+	next.start = p_next;
+	if (!text_range_valid(&next))
+		return keys;
+	size_t next_len = text_range_size(&next);
+	size_t dif = next_len - word_len;
+	if(dif <= 0) 
+		return keys;
+	buf = text_bytes_alloc0(txt, next.start + next_len - dif, dif);
+	if (!buf)
+		return keys;
+	// insert remaining word
+	for (Cursor *c = view_cursors(view); c; c = view_cursors_next(c)) {
+		text_insert(txt, view_cursors_pos(c), buf, dif);
+		view_cursors_scroll_to(c, view_cursors_pos(c));
+	}
+	free(buf);
 	return keys;
 }
 


### PR DESCRIPTION
I added the functionality to complete the current word with `<C-n>` in `insert mode`. This is similar to the autocomplete behaviour in VIM, except i just pick the first match by searching from the start of the file. It also works with multiple cursors.