### PR TITLE
test: add test for issue #276 in vis/multiple-cursors

### DIFF
--- a/test/vis/multiple-cursors/wqinterrupt.in
+++ b/test/vis/multiple-cursors/wqinterrupt.in
@@ -1,0 +1,4 @@
+1 : first
+2 : second
+3 : third
+4 : fourth

--- a/test/vis/multiple-cursors/wqinterrupt.keys
+++ b/test/vis/multiple-cursors/wqinterrupt.keys
@@ -1,0 +1,2 @@
+vGI             /* create cursor at start of every line */
+i/*                switch to insert mode, so that <Esc> after test leaves cursors active */

--- a/test/vis/multiple-cursors/wqinterrupt.ref
+++ b/test/vis/multiple-cursors/wqinterrupt.ref
@@ -1,0 +1,4 @@
+1 : first
+2 : second
+3 : third
+4 : fourth


### PR DESCRIPTION
A test for the issue [:wq while editing with multiple cursors deletes entire file contents](https://github.com/martanne/vis/issues/276). It relies on `:wq` being executed by `test/vis/test.sh` to create the side-effect that caused the original issue. Running the test requires rebasing `test` onto `master`.