### PR TITLE
Add `"` as a clipboard register (synonym to `+` and `*`)

### DIFF
--- a/main.c
+++ b/main.c
@@ -1250,7 +1250,7 @@ static const char *key2register(Vis *vis, const char *keys, enum VisRegister *re
 		*reg = keys[0] - 'a';
 	else if ('A' <= keys[0] && keys[0] <= 'Z')
 		*reg = VIS_REG_A + keys[0] - 'A';
-	else if (keys[0] == '*' || keys[0] == '+')
+	else if (keys[0] == '*' || keys[0] == '+' || keys[0] == '"')
 		*reg = VIS_REG_CLIPBOARD;
 	else if (keys[0] == '_')
 		*reg = VIS_REG_BLACKHOLE;


### PR DESCRIPTION
Almost no hope this will be approved, but still… `""y`, `""p` would rock, imho.

Adding `"` register as yet another synonym for `clipboard` would save some hand moves when interacting with the outer world (now you have to move your index-finger to press`*y` in a row or move your little finger for `"+`, which is slow). The `"` register will save one slow movement for the user. If user frequently copy/pastes text from/to another application this might be handy.
