### PR TITLE
vis-complete improvements

### DIFF
--- a/vis-complete
+++ b/vis-complete
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+basic_regex_quote() { printf "%s" "$1" | sed 's|[\\.*^$[]|\\&|g'; }
+glob_quote () { printf "%s" "$1" | sed 's|[\\?*[]]|\\&|g'; }
+
 PATTERN=""
 COMPLETE_WORD=0
 FIND_FILE_LIMIT=1000
@@ -26,7 +29,9 @@ while [ $# -gt 0 ]; do
 done
 
 if [ $COMPLETE_WORD = 1 ]; then
-	tr -cs '[:alnum:]_' '\n' | grep "^$PATTERN." | sort -u
+	tr -cs '[:alnum:]_' '\n' |
+		grep "^$(basic_regex_quote "$PATTERN")." |
+		sort -u
 else
 	case $PATTERN in
 		/*)
@@ -41,7 +46,7 @@ else
 	START=$(dirname "$PATTERN")
 	find "$START" \
 		! -path '*/\.*' \
-		-a -path "$PATTERN*" 2>/dev/null |
+		-a -path "$(glob_quote "$PATTERN")*" 2>/dev/null |
 		head -n $FIND_FILE_LIMIT |
 		sort
 fi |

--- a/vis-complete
+++ b/vis-complete
@@ -25,16 +25,8 @@ while [ $# -gt 0 ]; do
 	esac
 done
 
-PATTERN="$(echo "$PATTERN" | sed "s/'/'\\\\''/g")"
-
 if [ $COMPLETE_WORD = 1 ]; then
-	CMD=$(printf "tr -cs '[:alnum:]_' '\n' | grep '^%s.' | sort -u" "$PATTERN")
+	tr -cs '[:alnum:]_' '\n' | grep "^$PATTERN." | sort -u
 else
-	CMD=$(printf "find . ! -path '*/\.*' -a -path './%s*' 2>/dev/null | head -n $FIND_FILE_LIMIT | cut -b 3- | sort" "$PATTERN")
-fi
-
-PATTERN="$(echo "$PATTERN" | sed 's:/:\\/:g')"
-
-CMD=$(printf "$CMD | vis-menu -b | sed 's/^%s//' | tr -d '\n'" "$PATTERN")
-
-exec /bin/sh -c "$CMD"
+	find . ! -path '*/\.*' -a -path "./$PATTERN*" 2>/dev/null | head -n $FIND_FILE_LIMIT | cut -b 3- | sort
+fi | vis-menu -b | sed "s/^$(printf "%s" "$PATTERN" | sed 's:/:\\/:g' )//" | tr -d '\n'

--- a/vis-complete
+++ b/vis-complete
@@ -44,9 +44,16 @@ else
 	esac
 
 	START=$(dirname "$PATTERN")
+	# The first path condition rules out paths that start with "." unless
+	# they start with "..". That way, hidden paths should stay hidden, but
+	# non-normalised paths should still show up.
 	find "$START" \
-		! -path '*/\.*' \
-		-a -path "$(glob_quote "$PATTERN")*" 2>/dev/null |
+		-name '.*' -prune \
+		-o \( \
+			! -name '.*' \
+			-a -path "$(glob_quote "$PATTERN")*" \
+			-print \
+		\) 2>/dev/null |
 		head -n $FIND_FILE_LIMIT |
 		sort
 fi |

--- a/vis-complete
+++ b/vis-complete
@@ -28,5 +28,23 @@ done
 if [ $COMPLETE_WORD = 1 ]; then
 	tr -cs '[:alnum:]_' '\n' | grep "^$PATTERN." | sort -u
 else
-	find . ! -path '*/\.*' -a -path "./$PATTERN*" 2>/dev/null | head -n $FIND_FILE_LIMIT | cut -b 3- | sort
-fi | vis-menu -b | sed "s/^$(printf "%s" "$PATTERN" | sed 's:/:\\/:g' )//" | tr -d '\n'
+	case $PATTERN in
+		/*)
+			# An absolute path. This is fine.
+			;;
+		*)
+			# A relaive path. Let's make it absolute.
+			PATTERN=$PWD/$PATTERN
+			;;
+	esac
+
+	START=$(dirname "$PATTERN")
+	find "$START" \
+		! -path '*/\.*' \
+		-a -path "$PATTERN*" 2>/dev/null |
+		head -n $FIND_FILE_LIMIT |
+		sort
+fi |
+	vis-menu -b |
+	cut -b $(( ${#PATTERN} + 1 ))- |
+	tr -d '\n'


### PR DESCRIPTION
This PR improves vis-complete in the following ways:

- no more repeated shell-evaluation, so shell-sensitive characters in the pattern can't cause problems.
- the pattern is properly quoted before being handed to `grep`, so regex-sensitive characters can't cause problems
- the pattern is properly quoted before being handed to `find`, so glob-sensitive characters can't cause problems
- just as before, giving a relative path will complete relative to the current directory—but now, giving an absolute path works too

This code uses arithmetic expansion (`$(( ))`) but that's [definitely POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_04).