### PR TITLE
File completion updates

### DIFF
--- a/main.c
+++ b/main.c
@@ -2103,11 +2103,11 @@ static const char *open_file_under_cursor(Vis *vis, const char *keys, const Arg 
 	return keys;
 }
 
-static char *get_completion_prefix(Vis *vis) {
+static char *get_completion_prefix(Vis *vis, Filerange (*text_object)(Text *, size_t)) {
 	View *view = vis_view(vis);
 	Text *txt = vis_text(vis);
 
-	Filerange r = text_object_word(txt, view_cursor_get(view)-1);
+	Filerange r = text_object(txt, view_cursor_get(view)-1);
 	r = text_range_inner(txt, &r);
 	size_t size = text_range_size(&r);
 	if (size == 0) {
@@ -2140,7 +2140,7 @@ static const char *complete_word(Vis *vis, const char *keys, const Arg *arg) {
 	Text *txt = vis_text(vis);
 	Buffer cmd;
 	buffer_init(&cmd);
-	char *prefix = get_completion_prefix(vis);
+	char *prefix = get_completion_prefix(vis, text_object_word);
 	if (prefix && buffer_printf(&cmd, VIS_COMPLETE " --word '%s'", prefix)) {
 		Filerange all = text_range_new(0, text_size(txt));
 		insert_dialog_selection(vis, &all, (const char*[]){ buffer_content0(&cmd), NULL });
@@ -2153,7 +2153,7 @@ static const char *complete_word(Vis *vis, const char *keys, const Arg *arg) {
 static const char *complete_filename(Vis *vis, const char *keys, const Arg *arg) {
 	Buffer cmd;
 	buffer_init(&cmd);
-	char *prefix = get_completion_prefix(vis);
+	char *prefix = get_completion_prefix(vis, text_object_filename);
 	if (prefix && buffer_printf(&cmd, VIS_COMPLETE " --file '%s'", prefix)) {
 		Filerange empty = text_range_new(0, 0);
 		insert_dialog_selection(vis, &empty, (const char*[]){ buffer_content0(&cmd), NULL });

--- a/vis-complete
+++ b/vis-complete
@@ -28,21 +28,27 @@ while [ $# -gt 0 ]; do
 	esac
 done
 
-if [ $COMPLETE_WORD = 1 ]; then
-	tr -cs '[:alnum:]_' '\n' |
-		grep "^$(basic_regex_quote "$PATTERN")." |
-		sort -u
-else
+if [ $COMPLETE_WORD = 0 ]; then
 	case $PATTERN in
 		/*)
 			# An absolute path. This is fine.
+			;;
+		'~'|'~/'*)
+			# Expand tilde to $HOME
+			PATTERN=$HOME$(echo $PATTERN | tail -c +2)
 			;;
 		*)
 			# A relaive path. Let's make it absolute.
 			PATTERN=$PWD/$PATTERN
 			;;
 	esac
+fi
 
+if [ $COMPLETE_WORD = 1 ]; then
+	tr -cs '[:alnum:]_' '\n' |
+		grep "^$(basic_regex_quote "$PATTERN")." |
+		sort -u
+else
 	START=$(dirname "$PATTERN")
 	# The first path condition rules out paths that start with "." unless
 	# they start with "..". That way, hidden paths should stay hidden, but


### PR DESCRIPTION
 - Update `vis` to provide full file path to `vis-complete`.
 - Update `vis-complete` to expand tilde to `$HOME` when it's the first character in a file path.
 - Fix issue with `vis-complete` producing incorrect output for relative file paths. The `PATTERN` variable cannot be modified in a pipeline command as each command in a pipeline is run in its own subshell. This caused the value of `${#PATTERN}` to be incorrect for relative paths. This is resolved by modifying `PATTERN` before the pipeline is run.