### PR TITLE
man: Make vis-{clipboard,menu,open} manpages lint-clean.

### DIFF
--- a/vis-clipboard.1
+++ b/vis-clipboard.1
@@ -1,11 +1,11 @@
 .Dd November 29, 2016
-.Os Vis VERSION
 .Dt VIS-CLIPBOARD 1
-
+.Os Vis VERSION
+.
 .Sh NAME
 .Nm vis-clipboard
 .Nd Read from or write to the system clipboard
-
+.
 .Sh SYNOPSIS
 .Nm vis-clipboard
 .Fl -usable
@@ -15,7 +15,7 @@
 .Pp
 .Nm vis-clipboard
 .Fl -paste
-
+.
 .Sh DESCRIPTION
 .Nm vis-clipboard
 wraps various system-specific tools for interacting with a system clipboard,
@@ -51,30 +51,27 @@ In this mode,
 reads the content of the system clipboard,
 and writes it to standard output.
 .El
-
+.
 .Sh ENVIRONMENT
-
 The following environment variables affect the operation of
 .Nm vis-clipboard :
-
-.Bl -tag -width .Ev
+.Bl -tag -width Ev
 .It Ev DISPLAY
 If non-empty,
 .Nm vis-clipboard
 will prefer to access the X11 clipboard even if other options are available.
 .El
-
+.
 .Sh EXIT STATUS
 .Ex -std vis-clipboard
-
+.
 When run with the
 .Fl -usable
-flag, 
+flag,
 an exit status of 0 means that it found a supported system-specific tool,
 while 1 means that clipboard access is not available.
-
+.
 .Sh EXAMPLES
-
 Test whether clipboard access is available:
 .Bd -literal -offset indent
 if vis-clipboard --usable; then
@@ -83,23 +80,23 @@ else
 	echo "No clipboard"
 fi
 .Ed
-
+.Pp
 Copy a friendly greeting to the clipboard:
 .Bd -literal -offset indent
 echo "Hello, World" | vis-clipboard --copy
 .Ed
-
+.Pp
 Send the current contents of the system clipboard to be recorded and analyzed:
 .Bd -literal -offset indent
 vis-clipboard --paste | curl -d - https://www.nsa.gov/
 .Ed
-
+.
 .Sh SEE ALSO
 .Xr pbcopy 1 ,
 .Xr pbpaste 1 ,
+.Xr vis 1 ,
 .Xr xclip 1 ,
-.Xr xsel 1 ,
-.Xr vis 1
+.Xr xsel 1
+.
 .Sh AUTHORS
-
 .An "Marc Andr\('e Tanner" Aq mat@brain-dump.org

--- a/vis-menu.1
+++ b/vis-menu.1
@@ -1,11 +1,10 @@
 .Dd November 29, 2016
-.Os Vis VERSION
 .Dt VIS-MENU 1
-
+.Os Vis VERSION
 .Sh NAME
 .Nm vis-menu
 .Nd Interactively select an item from a list
-
+.
 .Sh SYNOPSIS
 .Nm vis-menu
 .Op Fl i
@@ -15,7 +14,7 @@
 .Op Ar initial
 .Nm vis-menu
 .Op Fl v
-
+.
 .Sh DESCRIPTION
 .Nm vis-menu
 allows a user to interactively select one item from a list of options.
@@ -74,7 +73,7 @@ Instead of displaying an interactive menu,
 .Nm vis-menu
 prints its version number to standard output and exits.
 .El
-
+.
 .Sh USAGE
 .Nm vis-menu
 displays the prompt (if any),
@@ -135,7 +134,7 @@ or
 .Sy Meta-v
 .Xc
 scrolls to show the next page of list items.
-.It Xo Sy Home 
+.It Xo Sy Home
 or
 .Sy Control-A
 .Xc
@@ -190,14 +189,12 @@ each space-delimited string is a separate filter
 and only items matching every filter will be shown.
 .Pp
 If the user filters out all the items from the list,
-then hits Enter to select the 
+then hits Enter to select the
 .Dq currently highlighted
 item,
 the text they typed will be returned instead.
-.Pp
-
+.
 .Sh EXAMPLES
-
 Here's a shell-script that allows the user to choose a number from one to 10:
 .Bd -literal -offset indent
 NUMBER=$(seq 1 10 | vis-menu -p "Choose a number")
@@ -207,7 +204,7 @@ else
 	echo "You refused to choose a number, or an error occurred."
 fi
 .Ed
-
+.
 .Sh DIAGNOSTICS
 The
 .Nm vis-menu
@@ -222,12 +219,12 @@ Potential error conditions include
 being unable to allocate memory,
 being unable to read from standard input,
 or being run without a controlling terminal.
-
+.
 .Sh SEE ALSO
 .Xr dmenu 1 ,
 .Xr slmenu 1 ,
 .Xr vis 1
-
+.
 .Sh HISTORY
 The original model for a single line menu reading items from standard input was
 .Xr dmenu 1
@@ -248,11 +245,9 @@ it was forked to become
 .Nm vis-menu
 to be distributed with
 .Xr vis 1 .
-
+.
 .Sh AUTHORS
-
 .An "Marc Andr\('e Tanner" Aq mat@brain-dump.org
-
 plus the
 .Nm slmenu
 and

--- a/vis-open.1
+++ b/vis-open.1
@@ -1,11 +1,11 @@
 .Dd November 29, 2016
-.Os Vis VERSION
 .Dt VIS-OPEN 1
-
+.Os Vis VERSION
+.
 .Sh NAME
 .Nm vis-open
 .Nd Interactively select a file to open
-
+.
 .Sh SYNOPSIS
 .Nm vis-open
 .Op Fl p Ar prompt
@@ -16,7 +16,7 @@
 .Nm vis-open
 .Fl h |
 .Fl -help
-
+.
 .Sh DESCRIPTION
 .Nm vis-open
 takes a list of filenames and directories on the command-line
@@ -33,7 +33,7 @@ uses
 .Xr vis-menu 1
 as its user-interface,
 so see that page for more details.
-
+.
 .Bl -tag -width flag
 .It Fl p Ar prompt
 Display
@@ -74,6 +74,8 @@ If present,
 .Nm vis-open
 prints a usage summary and exits,
 ignoring any other flag and arguments.
+.El
+.
 .Sh EXIT STATUS
 .Ex -std vis-open
 .Pp
@@ -83,6 +85,7 @@ like
 .Nm vis-open
 prints nothing and sets its exit status to 1
 if the user refused to select a file.
+.
 .Sh EXAMPLES
 .Bd -literal -offset indent
 CHOICE=$(vis-open -p "Select a file to stat")
@@ -92,13 +95,14 @@ else
 	stat "$CHOICE"
 fi
 .Ed
+.
 .Sh SEE ALSO
-.Xr vis-menu 1 ,
-.Xr vis 1
-
+.Xr vis 1 ,
+.Xr vis-menu 1
+.
 .Sh AUTHORS
 .An "Marc Andr\('e Tanner" Aq mat@brain-dump.org
-
+.
 .Sh BUGS
 Because
 .Nm vis-open


### PR DESCRIPTION
They now pass `mandoc -Tlint` (the BSD manpage renderer) and `man --warnings=w` (the GNU one).