### PR TITLE
visual-line substitute improvement

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -301,6 +301,7 @@ static const KeyBinding bindings_visual[] = {
 static const KeyBinding bindings_visual_line[] = {
 	{ "v",                  ACTION(MODE_VISUAL)                         },
 	{ "V",                  ACTION(MODE_NORMAL)                         },
+	{ "s",                  ALIAS("dO")                                 },
 	{ 0 /* empty last element, array terminator */                      },
 };
 


### PR DESCRIPTION
Slight tweak to visual-line mode substitute to make it act more like vim 8. 
Now alias `dO` instead of `c`, which removes the selected lines and insert a new line above and indents when applicable. This makes it easier to substitute content.