### PR TITLE
single: allow to build self-extracting executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /dependency
 /vis
 /vis-menu
+/vis-single
 *.css
 *.gcda
 *.gcno

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -185,4 +185,9 @@ standalone: clean
 		CFLAGS="-I$(DEPS_INC) --static -Wl,--as-needed" LDFLAGS="-L$(DEPS_LIB)" CC=musl-gcc
 	PATH=$(DEPS_BIN):$$PATH $(MAKE)
 
+single: standalone
+	cp vis-single.sh vis-single
+	strip vis
+	tar c vis lua/ | gzip -9 >> vis-single
+
 .PHONY: standalone local dependencies-common dependencies-local dependencies-clean

--- a/vis-single.sh
+++ b/vis-single.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+VISTMP="$(mktemp -d -p "${TMPDIR:-/tmp}" .vis-XXXXXX)"
+trap 'rm -rf "$VISTMP"' EXIT INT QUIT TERM HUP
+
+sed '1,/^__TAR_GZ_ARCHIVE_BELOW__$/d' "$0" | gzip -d | tar xC "$VISTMP"
+
+"$VISTMP/vis" "$@"
+
+exit $?
+
+__TAR_GZ_ARCHIVE_BELOW__


### PR DESCRIPTION
This allows to create a self extracting executable. The standalone
binary and lua files are extracted to /tmp/.vis-XXXXXX, vis is started
with the given command line arguments, finally temporary files are
removed.