### PR TITLE
standalone: work around borked dependencies in attr

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -178,7 +178,8 @@ dependency/build/libattr-build: dependency/build/libattr-configure
 	touch $@
 
 dependency/build/libattr-install: dependency/build/libattr-build
-	$(MAKE) -C $(dir $<)/$(LIBATTR) DESTDIR=$(DEPS_ROOT) install-lib install-dev
+	$(MAKE) -C $(dir $<)/$(LIBATTR)/libattr DESTDIR=$(DEPS_ROOT) install-dev
+	$(MAKE) -C $(dir $<)/$(LIBATTR)/include DESTDIR=$(DEPS_ROOT) install-dev
 	touch $@
 
 # LIBACL


### PR DESCRIPTION
We already did this change for acl (commit cc551cb0). In attr it shows
slightly different symptoms and happens for parallel builds only. The
fix is the same.