### PR TITLE
Allow {} to be nested in shell variables

### DIFF
--- a/lua/lexers/bash.lua
+++ b/lua/lexers/bash.lua
@@ -46,7 +46,7 @@ local identifier = token(l.IDENTIFIER, l.word)
 -- Variables.
 local variable = token(l.VARIABLE,
                        '$' * (S('!#?*@$') + l.digit^1 + l.word +
-                              l.delimited_range('{}', true, true)))
+                              l.delimited_range('{}', true, true, true)))
 
 -- Operators.
 local operator = token(l.OPERATOR, S('=!<>+-/*^&|~.,:;?()[]{}'))


### PR DESCRIPTION
This allows lines like

    : ${FOO:="${bar}/baz"}

to be highlighted correctly (without the nesting, the " after baz will
start a string that messes up the rest of the file.
