### PR TITLE
vis: reimplement `gf` and `<C-w>gf` functionality in lua

### DIFF
--- a/lua/vis-std.lua
+++ b/lua/vis-std.lua
@@ -146,3 +146,15 @@ vis:map(vis.modes.INSERT, "<C-k>", function(keys)
 	end
 	return #keys
 end, "Insert digraph")
+
+vis:map(vis.modes.NORMAL, "gf", function(keys)
+	local r = vis.win.file:text_object_longword(vis.win.cursor.pos)
+	local filename = vis.win.file:content(r)
+	local ok = vis:open(filename)
+	if not ok then
+		vis:info("Could not open file " .. filename .. " for reading.")
+	end
+	return #keys
+end, "Open file under cursor in a new window")
+
+vis:map(vis.modes.NORMAL, "<C-w>gf", "gf")

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -2308,6 +2308,7 @@ void vis_lua_init(Vis *vis) {
 		const char *name;
 	} textobjects[] = {
 		{ VIS_TEXTOBJECT_INNER_WORD, "text_object_word" },
+		{ VIS_TEXTOBJECT_INNER_LONGWORD, "text_object_longword" },
 	};
 
 	for (size_t i = 0; i < LENGTH(textobjects); i++) {


### PR DESCRIPTION
The functionality is not exactly identical since both bindings open the
file name under the cursor in a new window. The older implementation
opened the file in the same window with `gf` and in a new one with
`<C-w>gf`.

I added this key binding to the standard mapping because I use it a lot. Adding it as a plugin instead may make sense.