### PR TITLE
vis-lua: make vis:win assignable

### DIFF
--- a/vis-lua.c
+++ b/vis-lua.c
@@ -1169,6 +1169,11 @@ static int vis_newindex(lua_State *L) {
 			vis_count_set(vis, count);
 			return 1;
 		}
+
+		if (strcmp(key, "win") == 0) {
+			vis_window_focus(obj_ref_check(L, 3, VIS_LUA_TYPE_WINDOW));
+			return 0;
+		}
 	}
 	return newindex_common(L);
 }


### PR DESCRIPTION
I added this to write a plugin that executes commands in all windows. Tested with

```
require('vis')

local module = {}

function module.update()
	local active_window = vis.win
	for win in vis:windows() do
		vis.win = win
		if win == active_window then
			vis:command('set relativenumber on')
		else
			vis:command('set number on')
		end
	end
	vis.win = active_window
end

return module
```