### PR TITLE
Fix formatting in man page

### DIFF
--- a/man/vis.1
+++ b/man/vis.1
@@ -38,7 +38,7 @@ Execute
 after loading file.
 .
 .It Fl -
-Denotes  the  end  of the options.
+Denotes the end of the options.
 Arguments after this will be handled as a
 file name.
 .El
@@ -170,7 +170,7 @@ starts a recording,
 plays it back.
 .Ic @@
 refers to the most recently recorded macro.
-.Ic @":"
+.Ic @:
 repeats the last
 .Ic ":" Ns -command.
 .Ic @/


### PR DESCRIPTION
The double quotes were visible in the formatted output.