### PR TITLE
Fix compilation on GNU Hurd systems

### DIFF
--- a/util.h
+++ b/util.h
@@ -35,3 +35,14 @@ static void *memrchr(const void *m, int c, size_t n)
 #endif
 
 #endif /* UTIL_H */
+
+
+/* Needed for building on Hurd */
+
+#ifndef PIPE_BUF
+#define PIPE_BUF 4096
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif

--- a/util.h
+++ b/util.h
@@ -34,10 +34,7 @@ static void *memrchr(const void *m, int c, size_t n)
 }
 #endif
 
-#endif /* UTIL_H */
-
-
-/* Needed for building on Hurd */
+/* Needed for building on GNU Hurd */
 
 #ifndef PIPE_BUF
 #define PIPE_BUF 4096
@@ -46,3 +43,5 @@ static void *memrchr(const void *m, int c, size_t n)
 #ifndef PATH_MAX
 #define PATH_MAX 4096
 #endif
+
+#endif /* UTIL_H */


### PR DESCRIPTION
On GNU Hurd systems PIPE_BUF and PATH_MAX are not defined, and
the compilation fails. This patch defines them if they aren't.