### PR TITLE
fix format string for 32bit

### DIFF
--- a/main.c
+++ b/main.c
@@ -2004,7 +2004,7 @@ static const char *unicode_info(Vis *vis, const char *keys, const Arg *arg) {
 		else
 			buffer_appendf(&info, "<%s%.*s> ", combining ? " " : "", (int)len, codepoint);
 		if (arg->i == VIS_ACTION_UNICODE_INFO) {
-			buffer_appendf(&info, "U+%04x ", wc);
+			buffer_appendf(&info, "U+%04lx ", wc);
 		} else {
 			for (size_t i = 0; i < len; i++)
 				buffer_appendf(&info, "%02x ", (uint8_t)codepoint[i]);


### PR DESCRIPTION
The compiler reports:

main.c:2007:32: warning: format '%x' expects argument of type 'unsigned int',
but argument 3 has type 'wchar_t {aka long int}' [-Wformat=]
    buffer_appendf(&info, "U+%04x ", wc);