### PR TITLE
build: produce reproducible self contained executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,9 @@ vis-single-payload.inc: $(EXECUTABLES) lua/*
 	echo '#ifndef VIS_SINGLE_PAYLOAD_H' > $@
 	echo '#define VIS_SINGLE_PAYLOAD_H' >> $@
 	echo 'static unsigned char vis_single_payload[] = {' >> $@
-	tar --sort=name --mtime='2014-07-15 01:23Z' --owner=0 --group=0 --numeric-owner -c \
-		$(EXECUTABLES) $$(find lua -name '*.lua') | xz -T 1 | od -t x1 -A none -v | \
-		sed 's/\([0-9a-f]\+\)/0x\1,/g;$$s/,$$/ };/' >> $@
+	tar --mtime='2014-07-15 01:23Z' --owner=0 --group=0 --numeric-owner --mode='a+rX-w' -c \
+		$(EXECUTABLES) $$(find lua -name '*.lua' | LC_ALL=C sort) | xz -T 1 | \
+		od -t x1 -A none -v | sed 's/\([0-9a-f]\+\)/0x\1,/g;$$s/,$$/ };/' >> $@
 	echo '#endif' >> $@
 
 vis-single: vis-single.c vis-single-payload.inc


### PR DESCRIPTION
Giving tar the parameter '--sort=name' sorts direcory entries, but keeps
single files as-is. So instead sort the list retrieved by find.

Works for me. [TM] :D