### PR TITLE
Add option to hide EOF marker

### DIFF
--- a/man/vis.1
+++ b/man/vis.1
@@ -1315,6 +1315,9 @@ Whether to display replacement symbol instead of newlines.
 .It Cm show-spaces Op Cm off
 Whether to display replacement symbol instead of blank cells.
 .
+.It Cm show-eof Op Cm on
+Whether to display replacement symbol for lines after the end of the file.
+.
 .It Cm savemethod Op Ar auto
 How the current file should be saved,
 .Ar atomic

--- a/sam.c
+++ b/sam.c
@@ -289,6 +289,7 @@ enum {
 	OPTION_SHOW_SPACES,
 	OPTION_SHOW_TABS,
 	OPTION_SHOW_NEWLINES,
+	OPTION_SHOW_EOF,
 	OPTION_NUMBER,
 	OPTION_NUMBER_RELATIVE,
 	OPTION_CURSOR_LINE,
@@ -337,6 +338,11 @@ static const OptionDef options[] = {
 		{ "show-newlines" },
 		VIS_OPTION_TYPE_BOOL|VIS_OPTION_NEED_WINDOW,
 		VIS_HELP("Display replacement symbol for newlines")
+	},
+	[OPTION_SHOW_EOF] = {
+		{ "show-eof" },
+		VIS_OPTION_TYPE_BOOL|VIS_OPTION_NEED_WINDOW,
+		VIS_HELP("Display replacement symbol for lines after the end of the file")
 	},
 	[OPTION_NUMBER] = {
 		{ "numbers", "nu" },

--- a/view.c
+++ b/view.c
@@ -19,6 +19,7 @@ enum {
 	SYNTAX_SYMBOL_TAB,
 	SYNTAX_SYMBOL_TAB_FILL,
 	SYNTAX_SYMBOL_EOL,
+	SYNTAX_SYMBOL_EOF,
 	SYNTAX_SYMBOL_LAST,
 };
 
@@ -98,6 +99,7 @@ static const SyntaxSymbol symbols_none[] = {
 	[SYNTAX_SYMBOL_TAB]      = { " " },
 	[SYNTAX_SYMBOL_TAB_FILL] = { " " },
 	[SYNTAX_SYMBOL_EOL]      = { " " },
+	[SYNTAX_SYMBOL_EOF]      = { " " },
 };
 
 static const SyntaxSymbol symbols_default[] = {
@@ -105,6 +107,7 @@ static const SyntaxSymbol symbols_default[] = {
 	[SYNTAX_SYMBOL_TAB]      = { "›" /* Single Right-Pointing Angle Quotation Mark U+203A */ },
 	[SYNTAX_SYMBOL_TAB_FILL] = { " " },
 	[SYNTAX_SYMBOL_EOL]      = { "↵" /* Downwards Arrow with Corner Leftwards U+21B5 */ },
+	[SYNTAX_SYMBOL_EOF]      = { "~" },
 };
 
 static Cell cell_unused;
@@ -421,7 +424,7 @@ void view_draw(View *view) {
 	/* resync position of cursors within visible area */
 	for (Cursor *c = view->cursors; c; c = c->next) {
 		size_t pos = view_cursors_pos(c);
-		if (!view_coord_get(view, pos, &c->line, &c->row, &c->col) && 
+		if (!view_coord_get(view, pos, &c->line, &c->row, &c->col) &&
 		    c == view->cursor) {
 			c->line = view->topline;
 			c->row = 0;
@@ -514,7 +517,7 @@ View *view_new(Text *text) {
 	};
 	view->text = text;
 	view->tabwidth = 8;
-	view_options_set(view, 0);
+	view_options_set(view, UI_OPTION_SYMBOL_EOF);
 
 	if (!view_resize(view, 1, 1)) {
 		view_free(view);
@@ -830,6 +833,7 @@ void view_options_set(View *view, enum UiOption options) {
 		[SYNTAX_SYMBOL_TAB]      = UI_OPTION_SYMBOL_TAB,
 		[SYNTAX_SYMBOL_TAB_FILL] = UI_OPTION_SYMBOL_TAB_FILL,
 		[SYNTAX_SYMBOL_EOL]      = UI_OPTION_SYMBOL_EOL,
+		[SYNTAX_SYMBOL_EOF]      = UI_OPTION_SYMBOL_EOF,
 	};
 
 	for (int i = 0; i < LENGTH(mapping); i++) {
@@ -1345,6 +1349,10 @@ void view_selections_set(Selection *s, const Filerange *r) {
 
 Text *view_text(View *view) {
 	return view->text;
+}
+
+char *view_symbol_eof_get(View *view) {
+	return view->symbols[SYNTAX_SYMBOL_EOF]->symbol;
 }
 
 bool view_style_define(View *view, enum UiStyle id, const char *style) {

--- a/view.h
+++ b/view.h
@@ -195,6 +195,8 @@ Cursor *view_cursors_column(View*, int column);
 /* get next cursor (i.e. on another line) in zero based column */
 Cursor *view_cursors_column_next(Cursor*, int column);
 
+char *view_symbol_eof_get(View*);
+
 bool view_style_define(View*, enum UiStyle, const char *style);
 void view_style(View*, enum UiStyle, size_t start, size_t end);
 

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -269,11 +269,13 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Cursor
 	case OPTION_SHOW_SPACES:
 	case OPTION_SHOW_TABS:
 	case OPTION_SHOW_NEWLINES:
+	case OPTION_SHOW_EOF:
 	{
 		const int values[] = {
 			[OPTION_SHOW_SPACES] = UI_OPTION_SYMBOL_SPACE,
 			[OPTION_SHOW_TABS] = UI_OPTION_SYMBOL_TAB|UI_OPTION_SYMBOL_TAB_FILL,
 			[OPTION_SHOW_NEWLINES] = UI_OPTION_SYMBOL_EOL,
+			[OPTION_SHOW_EOF] = UI_OPTION_SYMBOL_EOF,
 		};
 		int flags = view_options_get(win->view);
 		if (arg.b || (toggle && !(flags & values[opt_index])))

--- a/vis-prompt.c
+++ b/vis-prompt.c
@@ -129,7 +129,7 @@ static const char *prompt_esc(Vis *vis, const char *keys, const Arg *arg) {
 static const char *prompt_up(Vis *vis, const char *keys, const Arg *arg) {
 	vis_motion(vis, VIS_MOVE_LINE_UP);
 	vis_window_mode_unmap(vis->win, VIS_MODE_INSERT, "<Up>");
-	view_options_set(vis->win->view, UI_OPTION_NONE);
+	view_options_set(vis->win->view, UI_OPTION_SYMBOL_EOF);
 	return keys;
 }
 

--- a/vis.c
+++ b/vis.c
@@ -306,7 +306,7 @@ static void window_draw_cursorline(Win *win) {
 		return;
 	if (view_cursors_multiple(view))
 		return;
-	
+
 	int width = view_width_get(view);
 	CellStyle style = win->ui->style_get(win->ui, UI_STYLE_CURSOR_LINE);
 	Cursor *cursor = view_cursors_primary_get(view);
@@ -420,7 +420,7 @@ static void window_draw_eof(Win *win) {
 		return;
 	CellStyle style = win->ui->style_get(win->ui, UI_STYLE_EOF);
 	for (Line *l = view_lines_last(view)->next; l; l = l->next) {
-		strcpy(l->cells[0].data, "~");
+		strcpy(l->cells[0].data, view_symbol_eof_get(view));
 		l->cells[0].style = style;
 	}
 }


### PR DESCRIPTION
Allows the user to type

```
:set show-eof off
```

to hide the tildes used as placeholders for empty lines.

It appears that such an option was already planned because the constant `UI_OPTION_SYMBOL_EOF` was already present in the code, it just wasn't implemented.
