### PR TITLE
Improve appearance of line numbers and EOF markers

### DIFF
--- a/lua/themes/solarized.lua
+++ b/lua/themes/solarized.lua
@@ -50,7 +50,7 @@ lexers.STYLE_WHITESPACE = ''
 lexers.STYLE_EMBEDDED = 'back:blue'
 lexers.STYLE_IDENTIFIER = fg
 
-lexers.STYLE_LINENUMBER = fg
+lexers.STYLE_LINENUMBER = 'fore:'..colors.base00..',back:'..colors.base02
 lexers.STYLE_CURSOR = 'fore:'..colors.base03..',back:'..colors.base0
 lexers.STYLE_CURSOR_PRIMARY = lexers.STYLE_CURSOR..',back:yellow'
 lexers.STYLE_CURSOR_LINE = 'back:'..colors.base02
@@ -61,4 +61,4 @@ lexers.STYLE_STATUS = 'back:'..colors.base00..',fore:'..colors.base02
 lexers.STYLE_STATUS_FOCUSED = 'back:'..colors.base1..',fore:'..colors.base02
 lexers.STYLE_SEPARATOR = lexers.STYLE_DEFAULT
 lexers.STYLE_INFO = 'fore:default,back:default,bold'
-lexers.STYLE_EOF = ''
+lexers.STYLE_EOF = 'fore:'..colors.base01


### PR DESCRIPTION
Line numbers and EOF markers currently look the same as regular text. This makes a file in which each line starts with a number or tilde visually indistinguishable from a file with line numbers or EOF markers enabled.

This PR tweaks the theme to add a "gutter" background familiar from other editors and make the foreground colors of line numbers and EOF markers less bright.

### Before

![theme_before](https://cloud.githubusercontent.com/assets/2702526/26761913/d7c44862-4927-11e7-8da9-3a7ed44df5da.png)

### After

![theme_after](https://cloud.githubusercontent.com/assets/2702526/26761921/ea852020-4927-11e7-8488-db28ce5072f6.png)
