### PR TITLE
Remove dependency dir from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /config.h
 /config.mk
-/dependency
 /vis
 /vis-menu
 /vis-single


### PR DESCRIPTION
With the removal of the standalone build target I think this can also also.