### PR TITLE
vis.1:  Surround with quotes link-name arguments of .Lk

### DIFF
--- a/man/vis.1
+++ b/man/vis.1
@@ -1539,21 +1539,21 @@ Spawn background process and pipe range to its standard input:
 .Xr vis-menu 1 ,
 .Xr vis-open 1
 .Pp
-.Lk http://doc.cat-v.org/bell_labs/sam_lang_tutorial/sam_tut.pdf A Tutorial for the Sam Command Language
+.Lk http://doc.cat-v.org/bell_labs/sam_lang_tutorial/sam_tut.pdf "A Tutorial for the Sam Command Language"
 by
 .An Rob Pike
 .Pp
-.Lk http://doc.cat-v.org/plan_9/4th_edition/papers/sam/ The Text Editor sam
+.Lk http://doc.cat-v.org/plan_9/4th_edition/papers/sam/ "The Text Editor sam"
 by
 .An Rob Pike
 .Pp
-.Lk http://man.cat-v.org/plan_9/1/sam Plan 9 manual page for sam(1)
+.Lk http://man.cat-v.org/plan_9/1/sam "Plan 9 manual page for sam(1)"
 .Pp
-.Lk http://doc.cat-v.org/bell_labs/structural_regexps/se.pdf Structural Regular Expressions
+.Lk http://doc.cat-v.org/bell_labs/structural_regexps/se.pdf "Structural Regular Expressions"
 by
 .An Rob Pike
 .Pp
-.Lk http://pubs.opengroup.org/onlinepubs/9699919799/utilities/vi.html vi - screen-oriented (visual) display editor St -p1003.1
+.Lk http://pubs.opengroup.org/onlinepubs/9699919799/utilities/vi.html "vi - screen-oriented (visual) display editor St -p1003.1"
 .
 .Sh STANDARDS
 .


### PR DESCRIPTION
As noted on mdoc(7), in groff  "Lk only accepts a single link-name argument; the remainder is misformatted.
The quotes makes groff treat the title as a single argument.

Note that double quotes where originally used, but where remove in
https://github.com/martanne/vis/commit/bee050696651d7740a54644f11adf21825a8c7f2#diff-1b1a076db28be546dfe17f39e05e60e1L1292