### PR TITLE
Reassign .cls file extension to latex

### DIFF
--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -195,7 +195,7 @@ vis.ftdetect.filetypes = {
 		ext = { "%.jsp$" },
 	},
 	latex = {
-		ext = { "%.bbl$", "%.dtx$", "%.ins$", "%.ltx$", "%.tex$", "%.sty$" },
+		ext = { "%.bbl$", "%.cls$", "%.dtx$", "%.ins$", "%.ltx$", "%.tex$", "%.sty$" },
 		mime = { "text/x-tex" },
 	},
 	ledger = {
@@ -381,7 +381,7 @@ vis.ftdetect.filetypes = {
 	},
 	vb = {
 		ext = {
-			"%.asa$", "%.bas$", "%.cls$", "%.ctl$", "%.dob$",
+			"%.asa$", "%.bas$", "%.ctl$", "%.dob$",
 			"%.dsm$", "%.dsr$", "%.frm$", "%.pag$", "%.vb$",
 			"%.vba$", "%.vbs$"
 		},


### PR DESCRIPTION
Both VB and LaTex use .cls file extensions. It should be a much more
reasonable default to assume LaTex syntax.

Unless there is some reasons i don't know about, it seems more sensible to me that LaTex has higher priority than Visual Basic.