### PR TITLE
vis-open: fix for absolute and non-existent paths

### DIFF
--- a/lua/plugins/complete-filename.lua
+++ b/lua/plugins/complete-filename.lua
@@ -6,7 +6,7 @@ vis:map(vis.modes.INSERT, "<C-x><C-f>", function()
 	local pos = win.selection.pos
 	if not pos then return end
 	-- TODO do something clever here
-	local range = file:text_object_word(pos > 0 and pos-1 or pos);
+	local range = file:text_object_longword(pos > 0 and pos-1 or pos);
 	if not range then return end
 	if range.finish > pos then range.finish = pos end
 	if range.start == range.finish then return end
@@ -29,7 +29,8 @@ vis:map(vis.modes.INSERT, "<C-x><C-o>", function()
 	local file = win.file
 	local pos = win.selection.pos
 	if not pos then return end
-	local range = file:text_object_word(pos > 0 and pos-1 or pos);
+	-- TODO do something clever here
+	local range = file:text_object_longword(pos > 0 and pos-1 or pos);
 	if not range then return end
 	if range.finish > pos then range.finish = pos end
 	local prefix = file:content(range)

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -2234,6 +2234,14 @@ static int file_mark_get(lua_State *L) {
  * @treturn Range range the range
  */
 
+/***
+ * WORD text object.
+ *
+ * @function text_object_longword
+ * @tparam int pos the position which must be part of the word
+ * @treturn Range range the range
+ */
+
 static int file_text_object(lua_State *L) {
 	Filerange range = text_range_empty();
 	File *file = obj_ref_check(L, 1, VIS_LUA_TYPE_FILE);
@@ -2703,6 +2711,7 @@ void vis_lua_init(Vis *vis) {
 		const char *name;
 	} textobjects[] = {
 		{ VIS_TEXTOBJECT_INNER_WORD, "text_object_word" },
+		{ VIS_TEXTOBJECT_INNER_LONGWORD, "text_object_longword" },
 	};
 
 	for (size_t i = 0; i < LENGTH(textobjects); i++) {

--- a/vis-open
+++ b/vis-open
@@ -40,6 +40,11 @@ if [ $# -eq 1 -a "$ALLOW_AUTO_SELECT" = 1 ]; then
 	# If there were globs on the command-line, they've expanded to
 	# a single item, so we can just process it.
 
+	# If the file or directory does not exist, abort.
+	if [ ! -e "$1" ]; then
+		exit 1
+	fi
+
 	if [ -d "$1" ]; then
 		# Recurse and show the contents of the named directory,
 		# We pass -f to force the next iteration to present the

--- a/vis-open
+++ b/vis-open
@@ -40,11 +40,6 @@ if [ $# -eq 1 -a "$ALLOW_AUTO_SELECT" = 1 ]; then
 	# If there were globs on the command-line, they've expanded to
 	# a single item, so we can just process it.
 
-	# If the file or directory does not exist, abort.
-	if [ ! -e "$1" ]; then
-		exit 1
-	fi
-
 	if [ -d "$1" ]; then
 		# Recurse and show the contents of the named directory,
 		# We pass -f to force the next iteration to present the
@@ -54,10 +49,15 @@ if [ $# -eq 1 -a "$ALLOW_AUTO_SELECT" = 1 ]; then
 		exec "$0" -p "$VIS_MENU_PROMPT" -f .. $(ls -1)
 	else
 		# We've found a single item, and it's not a directory,
-		# so it must be a filename (or file-like thing) to open.
-		cd "$(dirname "$1")"
-		echo "$(pwd -P)"/"$(basename "$1")"
-		exit 0
+		# so it must be a filename (or file-like thing) to open,
+		# unless the parent directory does not exist.
+		if [ -d "$(dirname "$1")" ]; then
+			cd "$(dirname "$1")"
+			echo "$(pwd -P)"/"$(basename "$1" | sed 's/\*$//')"
+			exit 0
+		else
+			exit 1
+		fi
 	fi
 fi
 


### PR DESCRIPTION
I've had some issues with vis-open and filename completion. As an example, try opening vis in your home directory and typing `:<Tab><Tab><Tab>`. You should end up with something like: `/home/$USER//:***`.

When the shell cannot find any matching files, the glob is not expanded, and vis-open will return the absolute path of the current working directory (because `dirname` prints `.`), followed by the filename, followed by a literal `*`. This commit checks that the final path actually exists, and if not, exits with status 1.

It also uses `text_object_longword` instead of `text_object_word` for the range to match, so that absolute paths are accepted, and replaced properly (else it only matches back to the first '/', and replaces from there. For example, in insert mode, try to  enter `/etc/host<C-x><C-o>`.

Please correct me if I've misunderstood anything, or have made any mistakes!