### PR TITLE
PHP lexer: stop line comments right before ?>

### DIFF
--- a/lua/lexers/php.lua
+++ b/lua/lexers/php.lua
@@ -11,7 +11,7 @@ local M = {_NAME = 'php'}
 local ws = token(l.WHITESPACE, l.space^1)
 
 -- Comments.
-local line_comment = (P('//') + '#') * l.nonnewline^0
+local line_comment = (P('//') + '#') * (l.nonnewline - '?>')^0
 local block_comment = '/*' * (l.any - '*/')^0 * P('*/')^-1
 local comment = token(l.COMMENT, block_comment + line_comment)
 


### PR DESCRIPTION
This allows to end PHP code sections. Otherwise token is treated as part of the comment and parser continues to parse whatever is after.