### PR TITLE
vis-complete: Show just basenames in vis-menu

### DIFF
--- a/lua/plugins/complete-filename.lua
+++ b/lua/plugins/complete-filename.lua
@@ -6,12 +6,15 @@ vis:map(vis.modes.INSERT, "<C-x><C-f>", function()
 	local pos = win.selection.pos
 	if not pos then return end
 	-- TODO do something clever here
-	local range = file:text_object_word(pos > 0 and pos-1 or pos);
+	local range = file:text_object_longword(pos > 0 and pos-1 or pos);
 	if not range then return end
 	if range.finish > pos then range.finish = pos end
 	if range.start == range.finish then return end
 	local prefix = file:content(range)
 	if not prefix then return end
+	-- Strip leading delimiters for some languages
+	i, j = string.find(prefix, "[[(<'\"]+")
+	if j then prefix = prefix:sub(j + 1) end
 	local cmd = string.format("vis-complete --file '%s'", prefix:gsub("'", "'\\''"))
 	local status, out, err = vis:pipe(file, { start = 0, finish = 0 }, cmd)
 	if status ~= 0 or not out then

--- a/vis-complete
+++ b/vis-complete
@@ -36,28 +36,30 @@ else
 	# Expand to absolute path because of the -path option below.
 	case $PATTERN in
 		/*)
+			XPATTERN=$PATTERN
 			;;
 		'~'|'~/'*)
-			PATTERN=$HOME$(echo $PATTERN | tail -c +2)
+			XPATTERN=$HOME$(echo $PATTERN | tail -c +2)
 			;;
 		*)
-			PATTERN=$PWD/$PATTERN
+			XPATTERN=$PWD/$PATTERN
 			;;
 	esac
 
 	# The first path condition rules out paths that start with "." unless
 	# they start with "..". That way, hidden paths should stay hidden, but
 	# non-normalised paths should still show up.
-	find $(dirname "$PATTERN") \
+	find $(dirname "$XPATTERN") \
 		-name '.*' -prune \
 		-o \( \
 			! -name '.*' \
-			-a -path "$(glob_quote "$PATTERN")*" \
+			-a -path "$(glob_quote "$XPATTERN")*" \
 			-print \
 		\) 2>/dev/null |
 		head -n $FIND_FILE_LIMIT |
-		sort
+		sort |
+		xargs -n1 basename
 fi |
 	vis-menu -b |
-	sed "s/^$(printf "%s" "$PATTERN" | sed 's:/:\\/:g' )//" |
+	sed "s/^$(basename $PATTERN)//" |
 	tr -d '\n'

--- a/vis-complete
+++ b/vis-complete
@@ -58,8 +58,8 @@ else
 		\) 2>/dev/null |
 		head -n $FIND_FILE_LIMIT |
 		sort |
-		xargs -n1 basename
+		sed "s|^$(dirname $XPATTERN)/||"
 fi |
 	vis-menu -b |
-	sed "s/^$(basename $PATTERN)//" |
+	sed "s|^$(basename $PATTERN)$(echo $PATTERN | tail -c 2 | fgrep /)||" |
 	tr -d '\n'

--- a/vis-complete
+++ b/vis-complete
@@ -28,32 +28,27 @@ while [ $# -gt 0 ]; do
 	esac
 done
 
-if [ $COMPLETE_WORD = 0 ]; then
-	case $PATTERN in
-		/*)
-			# An absolute path. This is fine.
-			;;
-		'~'|'~/'*)
-			# Expand tilde to $HOME
-			PATTERN=$HOME$(echo $PATTERN | tail -c +2)
-			;;
-		*)
-			# A relaive path. Let's make it absolute.
-			PATTERN=$PWD/$PATTERN
-			;;
-	esac
-fi
-
 if [ $COMPLETE_WORD = 1 ]; then
 	tr -cs '[:alnum:]_' '\n' |
 		grep "^$(basic_regex_quote "$PATTERN")." |
 		sort -u
 else
-	START=$(dirname "$PATTERN")
+	# Expand to absolute path because of the -path option below.
+	case $PATTERN in
+		/*)
+			;;
+		'~'|'~/'*)
+			PATTERN=$HOME$(echo $PATTERN | tail -c +2)
+			;;
+		*)
+			PATTERN=$PWD/$PATTERN
+			;;
+	esac
+
 	# The first path condition rules out paths that start with "." unless
 	# they start with "..". That way, hidden paths should stay hidden, but
 	# non-normalised paths should still show up.
-	find "$START" \
+	find $(dirname "$PATTERN") \
 		-name '.*' -prune \
 		-o \( \
 			! -name '.*' \

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -2703,6 +2703,7 @@ void vis_lua_init(Vis *vis) {
 		const char *name;
 	} textobjects[] = {
 		{ VIS_TEXTOBJECT_INNER_WORD, "text_object_word" },
+		{ VIS_TEXTOBJECT_INNER_LONGWORD, "text_object_longword" },
 	};
 
 	for (size_t i = 0; i < LENGTH(textobjects); i++) {


### PR DESCRIPTION
The common dirname part makes it harder to spot the right file, and fewer entries can be visible at once.

With only basenames, one can see quite a few more entries, and know in advance how many key presses (roughly) it would take to get to the desired file.