### PR TITLE
Support COLOR_PAIRS > SHRT_MAX

### DIFF
--- a/ui-terminal-curses.c
+++ b/ui-terminal-curses.c
@@ -41,7 +41,7 @@
 #  define NCURSES_EXT_COLORS 0
 # endif
 # if !NCURSES_EXT_COLORS
-#  define MAX_COLOR_PAIRS 256
+#  define MAX_COLOR_PAIRS MIN(COLOR_PAIRS, 256)
 # endif
 #endif
 #ifndef MAX_COLOR_PAIRS
@@ -179,7 +179,7 @@ static short color_pair_get(short fg, short bg) {
 		if (default_bg == -1)
 			default_bg = CELL_COLOR_BLACK;
 		has_default_colors = (use_default_colors() == OK);
-		color_pairs_max = MIN(COLOR_PAIRS, MAX_COLOR_PAIRS);
+		color_pairs_max = MIN(MAX_COLOR_PAIRS, SHRT_MAX);
 		if (COLORS)
 			color2palette = calloc((COLORS + 2) * (COLORS + 2), sizeof(short));
 	}


### PR DESCRIPTION
In ncurses 6.1, the TERMINAL structure was updated[0] to store data in `int`
instead of `short`, and terminfo definitions for 256-color terminals were
updated from `pairs#32767` to `pairs#0x10000`.

However, since vis stores the value of COLOR_PAIRS in a short (ncurses
internally stores it as an int), it is now overflowing into negative, breaking
color support completely.

The standard `init_pair` entry points still use `short` for their parameters, so
just restrict the pairs to `SHRT_MAX` during allocation.

[0] http://invisible-island.net/ncurses/announce-6.1.html#h4-new-library