### PR TITLE
Fix 'vis-single' target on FreeBSD

### DIFF
--- a/vis-single.c
+++ b/vis-single.c
@@ -9,6 +9,10 @@
 #include <string.h>
 #include <unistd.h>
 
+#ifdef __FreeBSD__
+#include <signal.h>
+#endif
+
 #include <lzma.h>
 #include <libuntar.h>
 


### PR DESCRIPTION
The 'vis-single' target fails to build on FreeBSD due to differences in core utilities and
missing definitions found in 'signal.h'

This might allow this to work on MacOS and other operating systems if they have similar
issues although it would require adjusting the uname check.

The if uname check in 'Makefile' might not be appropriate if worked before on systems
other than Linux.

