### PR TITLE
[security hotfix] buffer overflow vulnerability fix #679

### DIFF
--- a/view.c
+++ b/view.c
@@ -384,7 +384,7 @@ void view_draw(View *view) {
 		} else {
 			if (prev_cell.len && !view_addch(view, &prev_cell))
 				break;
-			pos += prev_cell.len;
+			pos += (prev_cell.len == 0? 1: prev_cell.len);
 			prev_cell = cell;
 		}
 


### PR DESCRIPTION
This pull request refers to issue #679

The solution is just a hotfix that is intended to leave the codebase as is, apply minimal semantic changes and prevent the buffer overflow identified in the issue linked above. The solution also takes care of error 2 highlighted in the issue linked above.

Much better solutions would be to completely redefine the way the function works, it is quite unclean from a semantic point of view.
I would separate all data and control information.
Avoid using too many unnecessary variables and try to handle `mbrtowc()` in a cleaner fashion.
Furthermore, it is unclear why many lines of code even exist to begin with (such as the one containing `strcat()`).
`view_draw` is a core part of vis and it deserves more attention.

If one does not wish to refactor the function, I suggest to at least take care of the 3 bugs highlighted by the issue linked above. It is still possible to trigger the overflow if incredibly long and particular unicode byte sequences are picked. While it is a difficult task, it does not hurt to completely prevent it from happening.

Further minor issues:
- some variables need to be initialized (e.g. `pwc`). This is good practice in C.
- `mbstate` needs to be handled accordingly. Documentation states that after finding an invalid multibyte sequence it should be reset (since effects to the state are undefined).

As a suggestion to solve all issues in one fell swoop, it might be a good idea to find a more resilient and complete all-in-one alternative to `mbrtowc()`.
