### PR TITLE
wip: Fix: /^ doesn't respect anchor.

### DIFF
--- a/text-motions.c
+++ b/text-motions.c
@@ -618,12 +618,12 @@ size_t text_search_forward(Text *txt, size_t pos, Regex *regex) {
 	size_t start = pos + 1;
 	size_t end = text_size(txt);
 	RegexMatch match[1];
-	bool found = start < end && !text_search_range_forward(txt, start, end - start, regex, 1, match, 0);
+	bool found = start < end && !text_search_range_forward(txt, start, end - start, regex, 1, match, (start > 0) ? REG_NOTBOL: 0);
 
 	if (!found) {
 		start = 0;
 		end = pos;
-		found = !text_search_range_forward(txt, start, end, regex, 1, match, 0);
+		found = !text_search_range_forward(txt, start, end, regex, 1, match, (start > 0) ? REG_NOTBOL: 0);
 	}
 
 	return found ? match[0].start : pos;
@@ -633,12 +633,12 @@ size_t text_search_backward(Text *txt, size_t pos, Regex *regex) {
 	size_t start = 0;
 	size_t end = pos;
 	RegexMatch match[1];
-	bool found = !text_search_range_backward(txt, start, end, regex, 1, match, 0);
+	bool found = !text_search_range_backward(txt, start, end, regex, 1, match, (start > 0) ? REG_NOTBOL: 0);
 
 	if (!found) {
 		start = pos + 1;
 		end = text_size(txt);
-		found = start < end && !text_search_range_backward(txt, start, end - start, regex, 1, match, 0);
+		found = start < end && !text_search_range_backward(txt, start, end - start, regex, 1, match, (start > 0) ? REG_NOTBOL: 0);
 	}
 
 	return found ? match[0].start : pos;


### PR DESCRIPTION
E.g. if a line is `fffff`, search forward will no longer return all the `f`s.
Fixes #685