### PR TITLE
remove indent error

### DIFF
--- a/lua/lexers/toml.lua
+++ b/lua/lexers/toml.lua
@@ -44,7 +44,7 @@ local keyword = token(l.KEYWORD, word_match{
 local identifier = token(l.IDENTIFIER, l.word)
 
 -- Operators.
-local operator = token(l.OPERATOR, S('#=+-,.{}[]()'))
+local operator = token(l.OPERATOR, S('=+-,.{}[]()'))
 
 M._rules = {
   {'indent', indent},

--- a/lua/lexers/toml.lua
+++ b/lua/lexers/toml.lua
@@ -9,7 +9,7 @@ local M = {_NAME = 'toml'}
 
 -- Whitespace
 local indent = #l.starts_line(S(' \t')) *
-               (token(l.WHITESPACE, ' ') + token('indent_error', '\t'))^1
+               (token(l.WHITESPACE, ' ')^1 + token(l.WHITESPACE, '\t'))^1
 local ws = token(l.WHITESPACE, S(' \t')^1 + l.newline^1)
 
 -- Comments.
@@ -59,7 +59,6 @@ M._rules = {
 }
 
 M._tokenstyles = {
-  indent_error = 'back:red',
   timestamp = l.STYLE_NUMBER,
 }
 

--- a/lua/lexers/toml.lua
+++ b/lua/lexers/toml.lua
@@ -34,6 +34,12 @@ local ts = token('timestamp', l.digit * l.digit * l.digit * l.digit * -- year
                                 S(' \t')^0 * S('-+') * l.digit * l.digit^-1 *
                                 (':' * l.digit * l.digit)^-1)^-1)^-1)
 
+-- table.
+local table = token('table', ('[[' * l.word * ('.' * l.word)^0 * ']]') +
+                             -- TODO: add quoted string support
+                             -- TODO: don't match if brackets aren't matched
+                             ('[' * l.word * ('.' * l.word)^0 * ']'))
+
 -- kewwords.
 local keyword = token(l.KEYWORD, word_match{
   'true', 'false'
@@ -44,12 +50,13 @@ local keyword = token(l.KEYWORD, word_match{
 local identifier = token(l.IDENTIFIER, l.word)
 
 -- Operators.
-local operator = token(l.OPERATOR, S('=+-,.{}[]()'))
+local operator = token(l.OPERATOR, S('=+-,.{}()'))
 
 M._rules = {
   {'indent', indent},
   {'whitespace', ws},
   {'keyword', keyword},
+  {'table', table},
   {'identifier', identifier},
   {'operator', operator},
   {'string', string},
@@ -60,6 +67,7 @@ M._rules = {
 
 M._tokenstyles = {
   timestamp = l.STYLE_NUMBER,
+  table = l.STYLE_KEYWORD,
 }
 
 M._FOLDBYINDENTATION = true


### PR DESCRIPTION
According to the [TOML github page][1], indentation can be tabs *and/or* spaces, so `indent_error` is removed. Don't know if the way I did it is the best way.

[1]: https://github.com/toml-lang/toml#example