### PR TITLE
WIP: Allow regexes to contain ␀ byte

### DIFF
--- a/text-regex-tre.c
+++ b/text-regex-tre.c
@@ -120,8 +120,11 @@ void text_regex_free(Regex *r) {
 	free(r);
 }
 
-int text_regex_compile(Regex *regex, const char *string, int cflags) {
-	int r = tre_regcomp(&regex->regex, string, cflags);
+int text_regex_compile(Regex *regex, const char *string, size_t len, int cflags) {
+	int r = len > 0
+	       ? tre_regncomp(&regex->regex, string, len, cflags)
+	       : tre_regcomp(&regex->regex, string, cflags);
+
 	if (r)
 		tre_regcomp(&regex->regex, "\0\0", 0);
 	return r;

--- a/text-regex.c
+++ b/text-regex.c
@@ -15,7 +15,7 @@ Regex *text_regex_new(void) {
 	return r;
 }
 
-int text_regex_compile(Regex *regex, const char *string, int cflags) {
+int text_regex_compile(Regex *regex, const char *string, size_t len, int cflags) {
 	int r = regcomp(&regex->regex, string, cflags);
 	if (r)
 		regcomp(&regex->regex, "\0\0", 0);

--- a/text-regex.h
+++ b/text-regex.h
@@ -13,7 +13,7 @@ typedef struct Regex Regex;
 typedef Filerange RegexMatch;
 
 Regex *text_regex_new(void);
-int text_regex_compile(Regex*, const char *pattern, int cflags);
+int text_regex_compile(Regex*, const char *pattern, size_t len, int cflags);
 size_t text_regex_nsub(Regex*);
 void text_regex_free(Regex*);
 int text_regex_match(Regex*, const char *data, int eflags);

--- a/vis-prompt.c
+++ b/vis-prompt.c
@@ -63,7 +63,7 @@ static const char *prompt_enter(Vis *vis, const char *keys, const Arg *arg) {
 			pattern = "^:";
 		else if (prompt->file == vis->search_file)
 			pattern = "^(/|\\?)";
-		if (pattern && regex && text_regex_compile(regex, pattern, REG_EXTENDED|REG_NEWLINE) == 0) {
+		if (pattern && regex && text_regex_compile(regex, pattern, 0, REG_EXTENDED|REG_NEWLINE) == 0) {
 			size_t end = text_line_end(txt, pos);
 			size_t prev = text_search_backward(txt, end, regex);
 			if (prev > pos)

--- a/vis.c
+++ b/vis.c
@@ -1646,16 +1646,18 @@ void vis_insert_nl(Vis *vis) {
 }
 
 Regex *vis_regex(Vis *vis, const char *pattern) {
-	if (!pattern && !(pattern = register_get(vis, &vis->registers[VIS_REG_SEARCH], NULL)))
+	size_t len = 0;
+	if (!pattern && !(pattern = register_get(vis, &vis->registers[VIS_REG_SEARCH], &len)))
 		return NULL;
 	Regex *regex = text_regex_new();
 	if (!regex)
 		return NULL;
-	if (text_regex_compile(regex, pattern, REG_EXTENDED|REG_NEWLINE) != 0) {
+	if (text_regex_compile(regex, pattern, len, REG_EXTENDED|REG_NEWLINE) != 0) {
 		text_regex_free(regex);
 		return NULL;
 	}
-	register_put0(vis, &vis->registers[VIS_REG_SEARCH], pattern);
+	if (len == 0)
+		register_put0(vis, &vis->registers[VIS_REG_SEARCH], pattern);
 	return regex;
 }
 


### PR DESCRIPTION
As previously noted in #359, vis has some trouble with searching in binary files. I noticed that the optional TRE library does actually support NUL bytes in the regex, and started modifying vis to make use of that.

With this patch, it's possible to search for NUL bytes by yanking such a pattern into the "/ register and then using n/N. It's not possible yet to enter a pattern containing NUL bytes directly, as the command line works with zero-terminated strings. Actually entering the pattern works fine, but it discards everything after the NUL byte. I haven't figured out how to change that yet.