### PR TITLE
add tab character to special characters array

### DIFF
--- a/text-motions.c
+++ b/text-motions.c
@@ -601,7 +601,7 @@ size_t text_bracket_match_symbol(Text *txt, size_t pos, const char *symbols) {
 		if (text_iterator_byte_next(&it, &c)) {
 			/* if a single or double quote is followed by
 			 * a special character, search backwards */
-			char special[] = " \n)}]>.,:;";
+			char special[] = " \t\n)}]>.,:;";
 			if (memchr(special, c, sizeof(special)))
 				direction = -1;
 		}


### PR DESCRIPTION
The special characters array doesn't contain the tab character thus causing issue #711.
By adding the tab character to the array, quotes are matched correctly across tab characters, too.
Although much less used, other white space characters such as \v, \f, and \r should perhaps be added as well.