### PR TITLE
Add ability to access tabwidth from Lua

### DIFF
--- a/vis-lua.c
+++ b/vis-lua.c
@@ -1364,6 +1364,10 @@ static int pipe_func(lua_State *L) {
  * @see windows
  */
 /***
+ * Current tabwidth.
+ * @tfield int tabwidth
+ */
+/***
  * Currently active mode.
  * @tfield modes mode
  */
@@ -1385,6 +1389,11 @@ static int vis_index(lua_State *L) {
 				obj_ref_new(L, vis->win, VIS_LUA_TYPE_WINDOW);
 			else
 				lua_pushnil(L);
+			return 1;
+		}
+
+		if (strcmp(key, "tabwidth") == 0) {
+			lua_pushunsigned(L, vis->tabwidth);
 			return 1;
 		}
 


### PR DESCRIPTION
This commit adds the ability to access the current tabwidth from a Lua
plugin. This can be used, for instance, to calculate the current column
in terms of character cells, instead of Unicode codepoints. I.e. a TAB
character could be counted as `tabwidth` character cells, instead of as
one.

My rationale for wanting this is that, as mentioned in the commit
message, it allows for calculating the current column, while
accounting for the width of a `\t`. Currently the statusbar at the bottom
shows the column in the way gotten out of `Selection.col`, which doesn't
account for the width of `\t` as set by the user. With this patch, we may
reach a middle ground of having the current statusbar stay as it is
while also allowing for a "tabwidth corrected" column count to exist.

Since Vis doesn't seem to have a way to query `set`-options, I feel
like this is the next best thing. I put this into `Vis.tabwidth` instead of something
like `Window.tabwidth` because by the looks of it, the `tabwidth` is universal.
If this was to change, however, it could be moved into `Window`.