### PR TITLE
solarized themed terms do not need bg and fg set again

### DIFF
--- a/lua/themes/solarized.lua
+++ b/lua/themes/solarized.lua
@@ -27,6 +27,10 @@ local bg = ',back:'..colors.base03..','
 -- light
 -- local fg = ',fore:'..colors.base03..','
 -- local bg = ',back:'..colors.base3..','
+-- solarized term
+-- local fg = ',fore:default,'
+-- local bg = ',back:default,'
+
 
 lexers.STYLE_DEFAULT = bg..fg
 lexers.STYLE_NOTHING = bg


### PR DESCRIPTION
When the terminal has a solarized theme, vis's theme does not need to set the background and foreground again. This is particularly useful with the solarized patch for st that allows switching the theme between light and dark on the fly, now vis's theme reflects that switch too.
Plus for issues related to setting the background color correctly, this is a work around - just set the term bg to solarized and the theme works. 