### PR TITLE
vis-lua: add file type detection for executable shell scripts

### DIFF
--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -41,7 +41,7 @@ vis.ftdetect.filetypes = {
 	},
 	bash = {
 		ext = { "%.bash$", "%.csh$", "%.sh$", "%.zsh$" },
-		mime = { "text/x-shellscript" },
+		mime = { "text/x-shellscript", "application/x-shellscript" },
 	},
 	batch = {
 		ext = { "%.bat$", "%.cmd$" },


### PR DESCRIPTION
`filetype.lua` currently doesn't recognize shell scripts if they are marked as executable (`chmod +x`). This pull request fixes that by adding `application/x-shellscript` as a MIME type associated with the `bash` file type.