### PR TITLE
redraw after mode change to ensure visual effects are changed

### DIFF
--- a/main.c
+++ b/main.c
@@ -2192,6 +2192,7 @@ static const char *join(Vis *vis, const char *keys, const Arg *arg) {
 
 static const char *switchmode(Vis *vis, const char *keys, const Arg *arg) {
 	vis_mode_switch(vis, arg->i);
+	vis_draw(vis);
 	return keys;
 }
 


### PR DESCRIPTION
My (succesful?) attempt at fixing my own issue #767 

In this issue the cursorline dissapears to late when mode switching.

Even when the vis.c draw_cursorline() (or something like that) is called
and propperly returns without drawing.

so the issue seems to be that the screen (or at least the portion what contains 
the cursor since the status bar [insert] does change to [normal] )

The PR is open for suggestions, this is my first contribution to the project and hope it is of any use, greetings o/