### PR TITLE
Minor improvements around text lexer and detection

### DIFF
--- a/lua/lexers/text.lua
+++ b/lua/lexers/text.lua
@@ -1,6 +1,15 @@
 -- Copyright 2006-2017 Mitchell mitchell.att.foicica.com. See LICENSE.
 -- Text LPeg lexer.
 
+local l = require('lexer')
+
 local M = {_NAME = 'text'}
+
+-- Whitespace.
+local ws = l.token(l.WHITESPACE, l.space^1)
+
+M._rules = {
+  {'whitespace', ws},
+}
 
 return M

--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -385,6 +385,10 @@ vis.ftdetect.filetypes = {
 	texinfo = {
 		ext = { "%.texi$" },
 	},
+	text = {
+		ext = { "%.txt$" },
+		mime = { "text/plain" },
+	},
 	toml = {
 		ext = { "%.toml$" },
 	},
@@ -495,6 +499,12 @@ vis.events.subscribe(vis.events.WIN_OPEN, function(win)
 				return
 			end
 		end
+	end
+
+	-- try text lexer as a last resort
+	if (mime or 'text/plain'):match('^text/.+$') then
+		set_filetype('text', vis.ftdetect.filetypes.text)
+		return
 	end
 
 	win:set_syntax(nil)


### PR DESCRIPTION
It's a text editor, so I think we can surely fallback to “text”–when applicable–instead of using nothing no lexers.

Because of how vis works, it's not a lucky case if you have any of `show-*` set and no lexers are used, because then these replacement characters will seem part of the text.