### PR TITLE
vis: don't search off screen when highlighting matches

### DIFF
--- a/text-motions.c
+++ b/text-motions.c
@@ -524,11 +524,11 @@ size_t text_parenthesis_end(Text *txt, size_t pos) {
 	return text_range_valid(&r) ? r.end : pos;
 }
 
-size_t text_bracket_match(Text *txt, size_t pos) {
-	return text_bracket_match_symbol(txt, pos, NULL);
+size_t text_bracket_match(Text *txt, size_t pos, Filerange const *limits) {
+	return text_bracket_match_symbol(txt, pos, NULL, limits);
 }
 
-static size_t match_symbol(Text *txt, size_t pos, char search, int direction) {
+static size_t match_symbol(Text *txt, size_t pos, char search, int direction, Filerange const *limits) {
 	char c, current;
 	int count = 1;
 	bool instring = false;
@@ -537,6 +537,8 @@ static size_t match_symbol(Text *txt, size_t pos, char search, int direction) {
 		return pos;
 	if (direction >= 0) { /* forward search */
 		while (text_iterator_byte_next(&it, &c)) {
+			if (limits && it.pos >= limits->end)
+				break;
 			if (c != current && c == '"')
 				instring = !instring;
 			if (!instring) {
@@ -548,6 +550,8 @@ static size_t match_symbol(Text *txt, size_t pos, char search, int direction) {
 		}
 	} else { /* backwards */
 		while (text_iterator_byte_prev(&it, &c)) {
+			if (limits && it.pos < limits->start)
+				break;
 			if (c != current && c == '"')
 				instring = !instring;
 			if (!instring) {
@@ -562,7 +566,7 @@ static size_t match_symbol(Text *txt, size_t pos, char search, int direction) {
 	return pos; /* no match found */
 }
 
-size_t text_bracket_match_symbol(Text *txt, size_t pos, const char *symbols) {
+size_t text_bracket_match_symbol(Text *txt, size_t pos, const char *symbols, Filerange const *limits) {
 	int direction;
 	char search, current, c;
 	Iterator it = text_iterator_get(txt, pos);
@@ -584,8 +588,8 @@ size_t text_bracket_match_symbol(Text *txt, size_t pos, const char *symbols) {
 	case '\'':
 	{
 		/* prefer matches on the same line */
-		size_t fw = match_symbol(txt, pos, current, +1);
-		size_t bw = match_symbol(txt, pos, current, -1);
+		size_t fw = match_symbol(txt, pos, current, +1, limits);
+		size_t bw = match_symbol(txt, pos, current, -1, limits);
 		if (fw == pos)
 			return bw;
 		if (bw == pos)
@@ -611,7 +615,7 @@ size_t text_bracket_match_symbol(Text *txt, size_t pos, const char *symbols) {
 		return pos;
 	}
 
-	return match_symbol(txt, pos, search, direction);
+	return match_symbol(txt, pos, search, direction, limits);
 }
 
 size_t text_search_forward(Text *txt, size_t pos, Regex *regex) {

--- a/text-motions.h
+++ b/text-motions.h
@@ -117,9 +117,9 @@ size_t text_block_end(Text*, size_t pos);
 size_t text_parenthesis_start(Text*, size_t pos);
 size_t text_parenthesis_end(Text*, size_t pos);
 /* search coresponding '(', ')', '{', '}', '[', ']', '>', '<', '"', ''' */
-size_t text_bracket_match(Text*, size_t pos);
+size_t text_bracket_match(Text*, size_t pos, Filerange const *);
 /* same as above but explicitly specify symbols to match */
-size_t text_bracket_match_symbol(Text*, size_t pos, const char *symbols);
+size_t text_bracket_match_symbol(Text*, size_t pos, const char *symbols, Filerange const *);
 
 /* search the given regex pattern in either forward or backward direction,
  * starting from pos. does wrap around if no match was found. */

--- a/text-objects.c
+++ b/text-objects.c
@@ -230,7 +230,7 @@ static Filerange text_object_bracket(Text *txt, size_t pos, char type) {
 	Iterator it = text_iterator_get(txt, pos);
 
 	if (open == close && text_iterator_byte_get(&it, &c) && (c == '"' || c == '`' || c == '\'')) {
-		size_t match = text_bracket_match(txt, pos);
+		size_t match = text_bracket_match(txt, pos, NULL);
 		r.start = MIN(pos, match) + 1;
 		r.end = MAX(pos, match);
 		return r;

--- a/vis-motions.c
+++ b/vis-motions.c
@@ -181,7 +181,7 @@ static size_t window_nop(Vis *vis, Win *win, size_t pos) {
 }
 
 static size_t bracket_match(Text *txt, size_t pos) {
-	size_t hit = text_bracket_match_symbol(txt, pos, "(){}[]<>'\"`");
+	size_t hit = text_bracket_match_symbol(txt, pos, "(){}[]<>'\"`", NULL);
 	if (hit != pos)
 		return hit;
 	char current;

--- a/vis.c
+++ b/vis.c
@@ -371,7 +371,8 @@ static void window_draw_cursor_matching(Win *win, Selection *cur, CellStyle *sty
 		return;
 	Line *line_match; int col_match;
 	size_t pos = view_cursors_pos(cur);
-	size_t pos_match = text_bracket_match_symbol(win->file->text, pos, "(){}[]\"'`");
+	Filerange limits = view_viewport_get(win->view);
+	size_t pos_match = text_bracket_match_symbol(win->file->text, pos, "(){}[]\"'`", &limits);
 	if (pos == pos_match)
 		return;
 	if (!view_coord_get(win->view, pos_match, &line_match, NULL, &col_match))


### PR DESCRIPTION
When the cursor is on a delimiter whose match should be highlighted, this patch limits the search to the viewport. If the matching delimiter is out of sight there's no point in highlighting it.

I found this when I had a very large binary file opened, and the cursor got stuck for a long time when i moved over a parenthesis.