### PR TITLE
build: install static libacl for docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV DIR /tmp/vis
 WORKDIR $DIR
 RUN apk update && apk add musl-dev fortify-headers gcc make libtermkey-dev \
 	ncurses-dev ncurses-static lua5.3-dev lua5.3-lpeg lua-lpeg-dev \
-	acl-dev xz-dev tar xz wget ca-certificates
+	acl-static acl-dev xz-dev tar xz wget ca-certificates
 RUN sed -i 's/Libs: /Libs: -L${INSTALL_CMOD} /' /usr/lib/pkgconfig/lua5.3.pc
 RUN mv /usr/lib/lua/5.3/lpeg.a /usr/lib/lua/5.3/liblpeg.a
 RUN sed -i 's/-ltermkey/-ltermkey -lunibilium/' /usr/lib/pkgconfig/termkey.pc

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ docker: clean
 	docker exec vis apk upgrade
 	docker cp . vis:/tmp/vis
 	docker exec vis sed -i '/^VERSION/c VERSION = $(VERSION)' Makefile
-	docker exec vis ./configure CC='cc --static'
+	docker exec vis ./configure CC='cc --static' --enable-acl
 	docker exec vis make clean vis-single
 	docker cp vis:/tmp/vis/vis-single vis
 	docker kill vis


### PR DESCRIPTION
Commit 50b0a580105ac976a1c95df9441d898d7a652bfb updated Alpine docker
image, however this broke building with acl support. The static libacl
moved to its own package, so just install that.