### PR TITLE
remove redundant layout option abbreviation

### DIFF
--- a/man/vis.1
+++ b/man/vis.1
@@ -1409,7 +1409,7 @@ caching layer or
 which tries the former for files smaller than 8Mb and the latter for
 lager ones. WARNING: modifying a memory mapped file in-place will
 cause data loss.
-.It Ic layout , Ic lay Op Do v Dc or Do h Dc
+.It Ic layout Op Do v Dc or Do h Dc
 Whether to use vertical or horizontal layout.
 
 .El

--- a/sam.c
+++ b/sam.c
@@ -382,7 +382,7 @@ static const OptionDef options[] = {
 		VIS_HELP("Change 256 color palette to support 24bit colors")
 	},
 	[OPTION_LAYOUT] = {
-		{ "layout", "lay" },
+		{ "layout" },
 		VIS_OPTION_TYPE_STRING,
 		VIS_HELP("Vertical or horizontal window layout")
 	},


### PR DESCRIPTION
Per [this](https://github.com/martanne/vis/pull/791#issuecomment-577598166) discussion:

No need to explicitly specify "lay" as an abbreviation, since "layout" already makes it available via prefix logic.