### PR TITLE
lexers: XML performance improvement

### DIFF
--- a/lua/lexers/xml.lua
+++ b/lua/lexers/xml.lua
@@ -20,13 +20,7 @@ local dq_str = l.delimited_range('"', false, true)
 local string = #S('\'"') * l.last_char_includes('=') *
                token(l.STRING, sq_str + dq_str)
 
-local in_tag = P(function(input, index)
-  local before = input:sub(1, index - 1)
-  local s, e = before:find('<[^>]-$'), before:find('>[^<]-$')
-  if s and e then return s > e and index or nil end
-  if s then return index end
-  return input:find('^[^<]->', index) and index or nil
-end)
+local in_tag = #P((1 - S"><")^0 * ">")
 
 -- Numbers.
 local number = #l.digit * l.last_char_includes('=') *


### PR DESCRIPTION
The new pattern isn't perfect, but the old one wasn't either.

One of its purposes was to highlight 123, but not 456 below:

```xml
<tag attr=123>text=456</tag>
```

Both the new and the old pattern can be tricked.
Here, 123 is not recognized as a token:
```xml
<tag glitch=">" attr=123 glitch="<">text=456</tag>
```

You can test it by positioning the cursor over one of the numbers and hitting `dii`.
If the _whole_ number is deleted, then it's recognized as a token.
(At least in the themes I use, numbers, even when recognized as such, are not highlighted any differently than text...)

Edit: forgot to mention, this is about issue #603.