### PR TITLE
lua: add <plugin>/init.lua to package.path

### DIFF
--- a/vis-lua.c
+++ b/vis-lua.c
@@ -2567,8 +2567,10 @@ bool vis_lua_path_add(Vis *vis, const char *path) {
 	lua_getglobal(L, "package");
 	lua_pushstring(L, path);
 	lua_pushstring(L, "/?.lua;");
-	lua_getfield(L, -3, "path");
-	lua_concat(L, 3);
+	lua_pushstring(L, path);
+	lua_pushstring(L, "/?/init.lua;");
+	lua_getfield(L, -5, "path");
+	lua_concat(L, 5);
 	lua_setfield(L, -2, "path");
 	lua_pop(L, 1); /* package */
 	return true;


### PR DESCRIPTION
This patch makes vis follow a Lua convention about modules, and also makes it easier to keep plugins up to date.
```lua
require'plugin'
```
will match both `plugin.lua` and `plugin/init.lua`.

Currently, most of the existing single-file plugins have the following structure - `vis-plugin/plugin.lua`, which is not a Lua convention or standard. One either has to

- download the individual file, losing the possibility to easily update it via git-pull,
- clone the repo, and use `require'vis-plugin.plugin'`
- clone the repo, add `~/.config/vis/vis-?/?.lua` to `package.path`, and use `require'plugin'`

With this change, just cloning a repo and `require`-ing its name would be enough,
and you get to use git-pull to check for any updates.

It doesn't harm the existing plugins in any way, AFAICT.