### PR TITLE
vis: restore mode when dot-repeating

### DIFF
--- a/vis.c
+++ b/vis.c
@@ -1528,6 +1528,7 @@ void vis_repeat(Vis *vis) {
 	else
 		count = vis->action_prev.count;
 	vis->action = vis->action_prev;
+	vis_mode_switch(vis, VIS_MODE_OPERATOR_PENDING);
 	vis_do(vis);
 	if (macro) {
 		Mode *mode = vis->mode;


### PR DESCRIPTION
This affects user-defined motions in Lua, which rely on `vis.mode` for mode-specific behaviour.
Kind of like `e` and `de`.
Unfortunately, when dot-repeating a combination that involves such motions, `vis.mode` is always NORMAL (instead of OPERATOR_PENDING), and this results in wrong changes. (_Very_ wrong, because my operators act on multiple, non-contiguous ranges.)

One of my plugins has several such motions. I had to develop a somewhat elaborate workaround to get them working, by registering _separate_ motions for each mode. It got ugly.
I hope you accept this patch (or suggest some equivalent), and I even have a patch ready for my plugin, to get rid of the hack - https://repo.or.cz/vis-parkour.git/commitdiff/simple-exclusivity