### PR TITLE
filetype: add more Prolog filename extensions

### DIFF
--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -294,7 +294,7 @@ vis.ftdetect.filetypes = {
 		ext = { "%.ps1$" },
 	},
 	prolog = {
-		ext = { "%.prolog$" },
+		ext = { "%.pl$", "%.pro$", "%.prolog$" },
 	},
 	props = {
 		ext = { "%.props$", "%.properties$" },


### PR DESCRIPTION
SWI-Prolog [prefers ".pl" and ".pro" extensions](https://www.swi-prolog.org/pldoc/man?section=projectfiles), in that order. It doesn't mention the current extension, ".prolog", however, loads files with this extension without issue.