### PR TITLE
Set single cursor style as primary, not secondary

### DIFF
--- a/vis.c
+++ b/vis.c
@@ -402,7 +402,6 @@ static void window_draw_cursor(Win *win, Selection *cur, CellStyle *style, CellS
 static void window_draw_selections(Win *win) {
 	View *view = win->view;
 	Filerange viewport = view_viewport_get(view);
-	bool multiple_cursors = view_selections_count(view) > 1;
 	Selection *sel = view_selections_primary_get(view);
 	CellStyle style_cursor = win->ui->style_get(win->ui, UI_STYLE_CURSOR);
 	CellStyle style_cursor_primary = win->ui->style_get(win->ui, UI_STYLE_CURSOR_PRIMARY);
@@ -415,7 +414,7 @@ static void window_draw_selections(Win *win) {
 		window_draw_cursor(win, s, &style_cursor, &style_selection);
 	}
 	window_draw_selection(win->view, sel, &style_selection);
-	window_draw_cursor(win, sel, multiple_cursors ? &style_cursor_primary : &style_cursor, &style_selection);
+	window_draw_cursor(win, sel, &style_cursor_primary, &style_selection);
 	for (Selection *s = view_selections_next(sel); s; s = view_selections_next(s)) {
 		window_draw_selection(win->view, s, &style_selection);
 		size_t pos = view_cursors_pos(s);


### PR DESCRIPTION
Currently vis defaults to rendering a single cursor using the secondary cursor color theme style - not sure how others feel about it but to me it makes more sense that it should be the primary, since there are no secondary cursors visible.

So that's what this patch does - your main cursor is always the same color, and any additional cursors are colored different.

If people disagree then perhaps we can add an option to toggle this behavior?