### PR TITLE
color-column: Don't change fg/bg if not set explicitly

### DIFF
--- a/ui-terminal-curses.c
+++ b/ui-terminal-curses.c
@@ -289,3 +289,7 @@ static void ui_curses_free(UiTerm *term) {
 	ui_curses_suspend(term);
 	endwin();
 }
+
+bool is_default_color(CellColor c) {
+	return c == CELL_COLOR_DEFAULT;
+}

--- a/ui-terminal-vt100.c
+++ b/ui-terminal-vt100.c
@@ -215,3 +215,7 @@ static void ui_vt100_free(UiTerm *tui) {
 	ui_vt100_suspend(tui);
 	buffer_release(&vtui->buf);
 }
+
+bool is_default_color(CellColor c) {
+	return c.index == ((CellColor) CELL_COLOR_DEFAULT).index;
+}

--- a/ui.h
+++ b/ui.h
@@ -115,4 +115,6 @@ struct UiWin {
 	int (*window_height)(UiWin*);
 };
 
+bool is_default_color(CellColor c);
+
 #endif

--- a/vis.c
+++ b/vis.c
@@ -27,6 +27,8 @@
 #include "util.h"
 #include "vis-core.h"
 #include "sam.h"
+#include "ui.h"
+
 
 static void macro_replay(Vis *vis, const Macro *macro);
 static void macro_replay_internal(Vis *vis, const Macro *macro);
@@ -294,7 +296,10 @@ static void window_draw_colorcolumn(Win *win) {
 
 		/* This screen line contains the cell we want to highlight */
 		if (cc <= line_cols + width) {
-			l->cells[(cc - 1) - line_cols].style = style;
+			CellStyle *orig = &l->cells[cc - 1 - line_cols].style;
+			orig->attr = style.attr;
+			orig->fg = is_default_color(style.fg) ? orig->fg : style.fg;
+			orig->bg = is_default_color(style.bg) ? orig->bg : style.bg;
 			line_cc_set = true;
 		} else {
 			line_cols += width;


### PR DESCRIPTION
eg. if your long line is a comment with green fg, and you set your
column color bg red while not specifying the fg, then the result is
green fg on red bg.

Prior to this change the result would be default fg on red bg, thus
one char in the long line of green text would look odd/wrong.

Of course if you do explicitly set the column color fg to default in your
theme then the result will not be what you expect - ideally we need
an UNSPECIFIED color type instead of relying on DEFAULT.

The `#if CONFIG_CURSORS` block is not ideal but I'm not sure what would be the right place to put it as currently all those defines are in other source files - is there a reason they're not in a header file?