### PR TITLE
Pass up terminal CSI as events to Lua.

### DIFF
--- a/lua/vis.lua
+++ b/lua/vis.lua
@@ -151,6 +151,7 @@ local events = {
 	WIN_HIGHLIGHT = "Event::WIN_HIGHLIGHT", -- see @{win_highlight}
 	WIN_OPEN = "Event::WIN_OPEN", -- see @{win_open}
 	WIN_STATUS = "Event::WIN_STATUS", -- see @{win_status}
+	TERM_CSI = "Event::TERM_CSI", -- see @{term_csi}
 }
 
 events.file_close = function(...) events.emit(events.FILE_CLOSE, ...) end
@@ -165,6 +166,7 @@ events.win_close = function(...) events.emit(events.WIN_CLOSE, ...) end
 events.win_highlight = function(...) events.emit(events.WIN_HIGHLIGHT, ...) end
 events.win_open = function(...) events.emit(events.WIN_OPEN, ...) end
 events.win_status = function(...) events.emit(events.WIN_STATUS, ...) end
+events.term_csi = function(...) events.emit(events.TERM_CSI, ...) end
 
 local handlers = {}
 

--- a/main.c
+++ b/main.c
@@ -2213,6 +2213,7 @@ int main(int argc, char *argv[]) {
 		.win_close = vis_lua_win_close,
 		.win_highlight = vis_lua_win_highlight,
 		.win_status = vis_lua_win_status,
+		.term_csi = vis_lua_term_csi,
 	};
 
 	vis = vis_new(ui_term_new(), &event);

--- a/vis-core.h
+++ b/vis-core.h
@@ -235,6 +235,7 @@ enum VisEvents {
 	VIS_EVENT_WIN_CLOSE,
 	VIS_EVENT_WIN_HIGHLIGHT,
 	VIS_EVENT_WIN_STATUS,
+	VIS_EVENT_TERM_CSI,
 };
 
 bool vis_event_emit(Vis*, enum VisEvents, ...);

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -161,6 +161,7 @@ void vis_lua_win_open(Vis *vis, Win *win) { }
 void vis_lua_win_close(Vis *vis, Win *win) { }
 void vis_lua_win_highlight(Vis *vis, Win *win) { }
 void vis_lua_win_status(Vis *vis, Win *win) { window_status_update(vis, win); }
+void vis_lua_term_csi(Vis *vis, const long *csi) { }
 
 #else
 
@@ -3071,6 +3072,26 @@ void vis_lua_win_status(Vis *vis, Win *win) {
 		pcall(vis, L, 1, 0);
 	} else {
 		window_status_update(vis, win);
+	}
+	lua_pop(L, 1);
+}
+
+/***
+ * CSI command received from terminal.
+ * @function term_csi
+ * @param List of CSI parameters
+ */
+void vis_lua_term_csi(Vis *vis, const long *csi) {
+	lua_State *L = vis->lua;
+	if (!L)
+		return;
+	vis_lua_event_get(L, "term_csi");
+	if (lua_isfunction(L, -1)) {
+		int nargs = csi[1];
+		lua_pushinteger(L, csi[0]);
+		for (int i = 0; i < nargs; i++)
+			lua_pushinteger(L, csi[2 + i]);
+		pcall(vis, L, 1 + nargs, 0);
 	}
 	lua_pop(L, 1);
 }

--- a/vis-lua.h
+++ b/vis-lua.h
@@ -37,5 +37,6 @@ void vis_lua_win_open(Vis*, Win*);
 void vis_lua_win_close(Vis*, Win*);
 void vis_lua_win_highlight(Vis*, Win*);
 void vis_lua_win_status(Vis*, Win*);
+void vis_lua_term_csi(Vis*, const long *);
 
 #endif

--- a/vis.h
+++ b/vis.h
@@ -57,6 +57,7 @@ typedef struct {
 	void (*win_close)(Vis*, Win*);
 	void (*win_highlight)(Vis*, Win*);
 	void (*win_status)(Vis*, Win*);
+	void (*term_csi)(Vis*, const long *);
 } VisEvent;
 
 /** Union used to pass arguments to key action functions. */


### PR DESCRIPTION
It allows to implement custom stuff such as mouse pointer or paste mode entirely in Lua.

In (neo)Vim, stuff like this is often hacked in really awkward and conflicting `map` fashion bound to scripts. I don't think doing so is wise as CSI are not really user input, but rather a state signal of the terminal emulator. Further complicated by that the CSI command itself is not actually a prefix code, but a last character in sequence (with variable data inbetween), making most of map-like binding useless.

An example of paste mode in visrc with this patch:

```lua
require 'vis'
local vis = vis
local io = io
local _ENV = setmetatable({}, {__index = function(t,k) return _ENV[k] or vis.events[k] or vis.modes[k] or function(...) return vis[k](vis, ...) end end })

command 'set expandtab'
command 'set autoindent'

-- enable/disable bracketed paste
subscribe(START, function() io.stdout:write("\x1b[?2004h"); io.stdout:flush() end)
subscribe(QUIT, function() io.stdout:write("\x1b[?2004l"); io.stdout:flush() end)

-- processing of bracketed pastes
subscribe(TERM_CSI, function(cmd, arg)
	if (cmd == 126) then
		if arg == 200 then
			command 'set expandtab off'
			command 'set autoindent off'
		elseif arg == 201 then
			command 'set expandtab'
			command 'set autoindent'
		end
	end
end)
```