### PR TITLE
filetype: do not match text/plain too early

### DIFF
--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -403,7 +403,8 @@ vis.ftdetect.filetypes = {
 	},
 	text = {
 		ext = { "%.txt$" },
-		mime = { "text/plain" },
+		-- Do *not* list mime "text/plain" here, it is covered below,
+		-- see 'try text lexer as a last resort'
 	},
 	toml = {
 		ext = { "%.toml$" },


### PR DESCRIPTION
This covers other detection, so make sure to match it in
last resort only.