### PR TITLE
lexers: add .ts as a javascript (until typescript gets its own)

### DIFF
--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -204,7 +204,7 @@ vis.ftdetect.filetypes = {
 		ext = { "%.bsh$", "%.java$" },
 	},
 	javascript = {
-		ext = { "%.js$", "%.jsfl$" },
+		ext = { "%.js$", "%.jsfl$", "%.ts$" },
 	},
 	json = {
 		ext = { "%.json$" },


### PR DESCRIPTION
Added .ts (typescript) as a javascript filetype, as typescript is a superset of javascript it seem to work ok until it gets its own lexer.