### PR TITLE
filetype: and Node.js module extensions

### DIFF
--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -204,7 +204,7 @@ vis.ftdetect.filetypes = {
 		ext = { "%.bsh$", "%.java$" },
 	},
 	javascript = {
-		ext = { "%.js$", "%.jsfl$", "%.ts$" },
+		ext = { "%.cjs$", "%.js$", "%.jsfl$", "%.mjs$", "%.ts$" },
 	},
 	json = {
 		ext = { "%.json$" },


### PR DESCRIPTION
Node.js uses `.mjs` and `.cjs` extensions, both are regular javascript.