### PR TITLE
Improve behavior of inner text objects when working linewise

### DIFF
--- a/vis.c
+++ b/vis.c
@@ -976,6 +976,9 @@ void vis_do(Vis *vis) {
 				if (a->textobj->type & TEXTOBJECT_DELIMITED_OUTER) {
 					r.start--;
 					r.end++;
+				} else if (linewise && (a->textobj->type & TEXTOBJECT_DELIMITED_INNER)) {
+					r.start = text_line_next(txt, r.start);
+					r.end = text_line_prev(txt, r.end);
 				}
 
 				if (vis->mode->visual || (i > 0 && !(a->textobj->type & TEXTOBJECT_NON_CONTIGUOUS)))


### PR DESCRIPTION
Currently inner and outer text objects both behave exactly the same for linewise operations. I think it would make a lot more sense to limit inner text objects to only the lines contained within the range. So for example right now `>i{` and `>a{` from with in this if
```c
if (linewise && (a->textobj->type & TEXTOBJECT_DELIMITED_INNER)) {
r.start = text_line_next(txt, r.start);
r.end = text_line_prev(txt, r.end);
}
```
both result in
```c
	if (linewise && (a->textobj->type & TEXTOBJECT_DELIMITED_INNER)) {
	r.start = text_line_next(txt, r.start);
	r.end = text_line_prev(txt, r.end);
	}
```

With these changes `>i{` would only affect the lines contained inside like so:

```c
if (linewise && (a->textobj->type & TEXTOBJECT_DELIMITED_INNER)) {
	r.start = text_line_next(txt, r.start);
	r.end = text_line_prev(txt, r.end);
}
```