### PR TITLE
lua: fix typo in lilypond file extension

### DIFF
--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -227,7 +227,7 @@ vis.ftdetect.filetypes = {
 		ext = { "%.less$" },
 	},
 	lilypond = {
-		ext = { "%.lily$", "%.ly$" },
+		ext = { "%.ily$", "%.ly$" },
 	},
 	lisp = {
 		ext = { "%.cl$", "%.el$", "%.lisp$", "%.lsp$" },


### PR DESCRIPTION
There is no .lily file but there is a .ily file in lilypond for stylesheets. 

They are like css for lilypond. I tested with the command `set syntax lilypond` on a .ily file.

The lilypond lexer works great for .ily too.

See here:

http://lilypond.org/doc/v2.18/Documentation/learning/style-sheets