### PR TITLE
text: ignore unused-result in error path

### DIFF
--- a/text-io.c
+++ b/text-io.c
@@ -242,7 +242,10 @@ static int mkstempat(int dirfd, char *template) {
 	fd = mkstemp(template);
 err:
 	if (cwd != -1) {
+#pragma GCC diagnostic ignored "-Wunused-result"
+		/* we are in error path and there's nothing we can do */
 		fchdir(cwd);
+#pragma GCC diagnostic pop
 		close(cwd);
 	}
 	return fd;


### PR DESCRIPTION
We are in error path and there's nothing we can do. Just ignore.

As clang tries to be compatible with gcc this should be portable.