### PR TITLE
lexers: fix bug in bash lexer for last here-doc

### DIFF
--- a/lua/lexers/bash.lua
+++ b/lua/lexers/bash.lua
@@ -20,15 +20,15 @@ local ex_str = l.delimited_range('`')
 local heredoc = '<<' * P(function(input, index)
   local s, e, minus, _, delimiter =
     input:find('(-?)(["\']?)([%a_][%w_]*)%2[\n\r\f;]+', index)
-  -- If the starting delimiter of a here-doc begins with "-", then
-  -- spaces are allowed to come before the closing delimiter.
-  local close_pattern
-  if minus == '-' then
-    close_pattern = '[\n\r\f%s]+'..delimiter..'\n'
-  else
-    close_pattern = '[\n\r\f]+'..delimiter..'\n'
-  end
   if s == index and delimiter then
+    -- If the starting delimiter of a here-doc begins with "-", then
+    -- spaces are allowed to come before the closing delimiter.
+    local close_pattern
+    if minus == '-' then
+      close_pattern = '[\n\r\f%s]+'..delimiter..'\n'
+    else
+      close_pattern = '[\n\r\f]+'..delimiter..'\n'
+    end
     local _, e = input:find(close_pattern, e)
     return e and e + 1 or #input + 1
   end


### PR DESCRIPTION
f4f0f5b allowed "<<-EOF" heredocs to be parsed correctly, but it
introduced a bug that made the lexer fail when the beginning of a
here-doc was the last string in a file (optionally followed only
by blanks).

In order to fix this, move everything regarding "delimiter" within
the block that is executed only if "delimiter" is not nil.