### PR TITLE
fix comment typos in vis.h

### DIFF
--- a/array.h
+++ b/array.h
@@ -100,7 +100,7 @@ bool array_truncate(Array*, size_t length);
  * Change length.
  * @rst
  * .. note:: Has to be less or equal than the capacity.
- *           Newly accesible elements preserve their previous values.
+ *           Newly accessible elements preserve their previous values.
  * @endrst
  */
 bool array_resize(Array*, size_t length);

--- a/buffer.h
+++ b/buffer.h
@@ -44,11 +44,11 @@ bool buffer_insert(Buffer*, size_t pos, const void *data, size_t len);
 bool buffer_insert0(Buffer*, size_t pos, const char *data);
 /** Append further content to the end. */
 bool buffer_append(Buffer*, const void *data, size_t len);
-/** Append NUl-terminated data. */
+/** Append NUL-terminated data. */
 bool buffer_append0(Buffer*, const char *data);
-/** Insert ``len`` bytes of ``data`` at the begin. */
+/** Insert ``len`` bytes of ``data`` at the start. */
 bool buffer_prepend(Buffer*, const void *data, size_t len);
-/** Insert NUL-terminated data at the begin. */
+/** Insert NUL-terminated data at the start. */
 bool buffer_prepend0(Buffer*, const char *data);
 /** Set formatted buffer content, ensures NUL termination on success. */
 bool buffer_printf(Buffer*, const char *fmt, ...) __attribute__((format(printf, 2, 3)));

--- a/sam.c
+++ b/sam.c
@@ -145,7 +145,7 @@ static bool cmd_user(Vis*, Win*, Command*, const char *argv[], Selection*, Filer
 
 static const CommandDef cmds[] = {
 	//      name            help
-	//      flags, default command, implemenation
+	//      flags, default command, implementation
 	{
 		"a",            VIS_HELP("Append text after range")
 		CMD_TEXT, NULL, cmd_append
@@ -278,7 +278,7 @@ typedef struct {
 	const char *names[3];            /* name and optional alias */
 	enum VisOption flags;            /* option type, etc. */
 	VIS_HELP_DECL(const char *help;) /* short, one line help text */
-	VisOptionFunction *func;         /* option handler, NULL for bulitins */
+	VisOptionFunction *func;         /* option handler, NULL for builtins */
 	void *context;                   /* context passed to option handler function */
 } OptionDef;
 

--- a/text-io.c
+++ b/text-io.c
@@ -33,7 +33,7 @@ struct TextSave {                  /* used to hold context between text_save_{be
 #define BLOCK_SIZE (1 << 20)
 #endif
 /* Files smaller than this value are copied on load, larger ones are mmap(2)-ed
- * directely. Hence the former can be truncated, while doing so on the latter
+ * directly. Hence the former can be truncated, while doing so on the latter
  * results in havoc. */
 #define BLOCK_MMAP_SIZE (1 << 26)
 
@@ -261,7 +261,7 @@ err:
  *   - file ownership can not be preserved
  *   - file group can not be preserved
  *   - directory permissions do not allow creation of a new file
- *   - POSXI ACL can not be preserved (if enabled)
+ *   - POSIX ACL can not be preserved (if enabled)
  *   - SELinux security context can not be preserved (if enabled)
  */
 static bool text_save_begin_atomic(TextSave *ctx) {

--- a/text-motions.h
+++ b/text-motions.h
@@ -1,8 +1,8 @@
 #ifndef TEXT_MOTIONS_H
 #define TEXT_MOTIONS_H
 
-/* these function all take a position in bytes from the start of the file,
- * perform a certain movement and return the new postion. if the movement
+/* these functions all take a position in bytes from the start of the file,
+ * perform a certain movement and return the new postion. If the movement
  * is not possible the original position is returned unchanged. */
 
 #include <stddef.h>
@@ -20,7 +20,7 @@ size_t text_codepoint_next(Text*, size_t pos);
 size_t text_codepoint_prev(Text*, size_t pos);
 
 /* find the given substring either in forward or backward direction.
- * does not wrap around at file start / end. if no match is found return
+ * does not wrap around at file start / end. If no match is found return
  * original position */
 size_t text_find_next(Text*, size_t pos, const char *s);
 size_t text_find_prev(Text*, size_t pos, const char *s);
@@ -69,7 +69,7 @@ size_t text_range_line_prev(Text*, Filerange*, size_t pos);
 /*
  * A longword consists of a sequence of non-blank characters, separated with
  * white space. TODO?: An empty line is also considered to be a word.
- * This is equivalant to a WORD in vim terminology.
+ * This is equivalent to a WORD in vim terminology.
  */
 size_t text_longword_end_next(Text*, size_t pos);
 size_t text_longword_end_prev(Text*, size_t pos);
@@ -79,7 +79,7 @@ size_t text_longword_start_prev(Text*, size_t pos);
  * A word consists of a sequence of letters, digits and underscores, or a
  * sequence of other non-blank characters, separated with white space.
  * TODO?: An empty line is also considered to be a word.
- * This is equivalant to a word (lowercase) in vim terminology.
+ * This is equivalent to a word (lowercase) in vim terminology.
  */
 size_t text_word_end_next(Text*, size_t pos);
 size_t text_word_end_prev(Text*, size_t pos);
@@ -116,13 +116,13 @@ size_t text_block_start(Text*, size_t pos);
 size_t text_block_end(Text*, size_t pos);
 size_t text_parenthesis_start(Text*, size_t pos);
 size_t text_parenthesis_end(Text*, size_t pos);
-/* search coresponding '(', ')', '{', '}', '[', ']', '>', '<', '"', ''' */
+/* search corresponding '(', ')', '{', '}', '[', ']', '>', '<', '"', ''' */
 size_t text_bracket_match(Text*, size_t pos, const Filerange *limits);
 /* same as above but explicitly specify symbols to match */
 size_t text_bracket_match_symbol(Text*, size_t pos, const char *symbols, const Filerange *limits);
 
 /* search the given regex pattern in either forward or backward direction,
- * starting from pos. does wrap around if no match was found. */
+ * starting from pos. Does wrap around if no match was found. */
 size_t text_search_forward(Text *txt, size_t pos, Regex *regex);
 size_t text_search_backward(Text *txt, size_t pos, Regex *regex);
 

--- a/text-objects.h
+++ b/text-objects.h
@@ -1,8 +1,8 @@
 #ifndef TEXT_OBJECTS_H
 #define TEXT_OBJECTS_H
 
-/* these functions all take a file position. if this position is part of the
- * respective text-object, a corresponding range is returned. if there is no
+/* these functions all take a file position. If this position is part of the
+ * respective text-object, a corresponding range is returned. If there is no
  * such text-object at the given location, an empty range is returned.
  */
 
@@ -13,13 +13,13 @@
 Filerange text_object_entire(Text*, size_t pos);
 /* word which happens to be at pos without any neighbouring white spaces */
 Filerange text_object_word(Text*, size_t pos);
-/* includes trailing white spaces. if at pos happens to be a white space
+/* includes trailing white spaces. If at pos happens to be a white space
  * include all neighbouring leading white spaces and the following word. */
 Filerange text_object_word_outer(Text*, size_t pos);
-/* find next occurance of `word' (as word not substring) in forward/backward direction */
+/* find next occurence of `word' (as word not substring) in forward/backward direction */
 Filerange text_object_word_find_next(Text*, size_t pos, const char *word);
 Filerange text_object_word_find_prev(Text*, size_t pos, const char *word);
-/* find next occurance of a literal string (not regex) in forward/backward direction */
+/* find next occurence of a literal string (not regex) in forward/backward direction */
 Filerange text_object_find_next(Text *txt, size_t pos, const char *search);
 Filerange text_object_find_prev(Text *txt, size_t pos, const char *search);
 /* same semantics as above but for a longword (i.e. delimited by white spaces) */
@@ -44,7 +44,7 @@ Filerange text_object_backtick(Text*, size_t pos);
 /* match a search term in either forward or backward direction */
 Filerange text_object_search_forward(Text*, size_t pos, Regex*);
 Filerange text_object_search_backward(Text*, size_t pos, Regex*);
-/* match all lines with same indendation level than the current one */
+/* match all lines with same indentation level as the current one */
 Filerange text_object_indentation(Text*, size_t pos);
 
 /* extend a range to cover whole lines */

--- a/text.c
+++ b/text.c
@@ -24,7 +24,7 @@
  * All active pieces chained together form the whole content of the document.
  * At the beginning there exists only one piece, spanning the whole document.
  * Upon insertion/deletion new pieces will be created to represent the changes.
- * Generally pieces are never destroyed, but kept around to peform undo/redo
+ * Generally pieces are never destroyed, but kept around to perform undo/redo
  * operations.
  */
 struct Piece {
@@ -123,7 +123,7 @@ static void lineno_cache_invalidate(LineCache *cache);
 static size_t lines_skip_forward(Text *txt, size_t pos, size_t lines, size_t *lines_skiped);
 static size_t lines_count(Text *txt, size_t pos, size_t len);
 
-/* stores the given data in a block, allocates a new one if necessary. returns
+/* stores the given data in a block, allocates a new one if necessary. Returns
  * a pointer to the storage location or NULL if allocation failed. */
 static const char *block_store(Text *txt, const char *data, size_t len) {
 	Block *blk = array_get_ptr(&txt->blocks, array_length(&txt->blocks)-1);
@@ -167,8 +167,8 @@ static bool cache_contains(Text *txt, Piece *p) {
 	return found && p->data + p->len == blk->data + blk->len;
 }
 
-/* try to insert a chunk of data at a given piece offset. the insertion is only
- * performed if the piece is the most recenetly changed one. the legnth of the
+/* try to insert a chunk of data at a given piece offset. The insertion is only
+ * performed if the piece is the most recently changed one. The length of the
  * piece, the span containing it and the whole text is adjusted accordingly */
 static bool cache_insert(Text *txt, Piece *p, size_t off, const char *data, size_t len) {
 	if (!cache_contains(txt, p))
@@ -183,9 +183,9 @@ static bool cache_insert(Text *txt, Piece *p, size_t off, const char *data, size
 	return true;
 }
 
-/* try to delete a chunk of data at a given piece offset. the deletion is only
- * performed if the piece is the most recenetly changed one and the whole
- * affected range lies within it. the legnth of the piece, the span containing it
+/* try to delete a chunk of data at a given piece offset. The deletion is only
+ * performed if the piece is the most recently changed one and the whole
+ * affected range lies within it. The length of the piece, the span containing it
  * and the whole text is adjusted accordingly */
 static bool cache_delete(Text *txt, Piece *p, size_t off, size_t len) {
 	if (!cache_contains(txt, p))
@@ -316,9 +316,9 @@ static void piece_init(Piece *p, Piece *prev, Piece *next, const char *data, siz
 	p->len = len;
 }
 
-/* returns the piece holding the text at byte offset pos. if pos happens to
- * be at a piece boundry i.e. the first byte of a piece then the previous piece
- * to the left is returned with an offset of piece->len. this is convenient for
+/* returns the piece holding the text at byte offset pos. If pos happens to
+ * be at a piece boundary i.e. the first byte of a piece then the previous piece
+ * to the left is returned with an offset of piece->len. This is convenient for
  * modifications to the piece chain where both pieces (the returned one and the
  * one following it) are needed, but unsuitable as a public interface.
  *
@@ -335,8 +335,8 @@ static Location piece_get_intern(Text *txt, size_t pos) {
 	return (Location){ 0 };
 }
 
-/* similiar to piece_get_intern but usable as a public API. returns the piece
- * holding the text at byte offset pos. never returns a sentinel piece.
+/* similiar to piece_get_intern but usable as a public API. Returns the piece
+ * holding the text at byte offset pos. Never returns a sentinel piece.
  * it pos is the end of file (== text_size()) and the file is not empty then
  * the last piece holding data is returned.
  */
@@ -447,8 +447,8 @@ bool text_insert(Text *txt, size_t pos, const char *data, size_t len) {
 		span_init(&c->new, new, new);
 		span_init(&c->old, NULL, NULL);
 	} else {
-		/* insert into middle of an existing piece, therfore split the old
-		 * piece. that is we have 3 new pieces one containing the content
+		/* insert into middle of an existing piece, therefore split the old
+		 * piece. That is we have 3 new pieces one containing the content
 		 * before the insertion point then one holding the newly inserted
 		 * text and one holding the content after the insertion point.
 		 */
@@ -644,7 +644,7 @@ Block *text_block_mmaped(Text *txt) {
 }
 
 /* A delete operation can either start/stop midway through a piece or at
- * a boundry. In the former case a new piece is created to represent the
+ * a boundary. In the former case a new piece is created to represent the
  * remaining text before/after the modification point.
  *
  *      /-+ --> +---------+ --> +-----+ --> +-----+ --> +-\
@@ -683,7 +683,7 @@ bool text_delete(Text *txt, size_t pos, size_t len) {
 	size_t cur;            /* how much has already been deleted */
 
 	if (off == p->len) {
-		/* deletion starts at a piece boundry */
+		/* deletion starts at a piece boundary */
 		cur = 0;
 		before = p;
 		start = p->next;
@@ -704,7 +704,7 @@ bool text_delete(Text *txt, size_t pos, size_t len) {
 	}
 
 	if (cur == len) {
-		/* deletion stops at a piece boundry */
+		/* deletion stops at a piece boundary */
 		end = p;
 		after = p->next;
 	} else {

--- a/text.h
+++ b/text.h
@@ -75,13 +75,13 @@ enum TextLoadMethod {
 	 */
 	TEXT_LOAD_READ,
 	/**
-	 * Memory map the the file from disk. Use file system / virtual memory
+	 * Memory map the file from disk. Use file system / virtual memory
 	 * subsystem as a caching layer.
 	 * @rst
 	 * .. note:: Load time is (almost) independent of the file size.
 	 * .. warning:: Inplace modifications of the underlying file
 	 *              will be reflected in the current text content.
-	 *              In particular, truncatenation will raise ``SIGBUS``
+	 *              In particular, truncation will raise ``SIGBUS``
 	 *              and result in data loss.
 	 * @endrst
 	 */
@@ -111,7 +111,7 @@ Text *text_loadat(int dirfd, const char *filename);
  */
 Text *text_load_method(const char *filename, enum TextLoadMethod);
 Text *text_loadat_method(int dirfd, const char *filename, enum TextLoadMethod);
-/** Release all ressources associated with this text instance. */
+/** Release all resources associated with this text instance. */
 void text_free(Text*);
 /**
  * @}
@@ -164,7 +164,7 @@ bool text_appendf(Text*, const char *format, ...) __attribute__((format(printf, 
  * @{
  */
 /**
- * Create a text snapshot, that is a vertice in the history graph.
+ * Create a text snapshot, that is a vertex in the history graph.
  */
 bool text_snapshot(Text*);
 /**
@@ -237,7 +237,7 @@ size_t text_bytes_get(const Text*, size_t pos, size_t len, char *buf);
  * Fetch text range into newly allocate memory region.
  * @param pos The absolute starting position.
  * @param len The length in bytes.
- * @return A contigious NUL terminated buffer holding the requested range, or
+ * @return A contiguous NUL terminated buffer holding the requested range, or
  *         ``NULL`` in error case.
  * @rst
  * .. warning:: The returned pointer must be freed by the caller.
@@ -329,7 +329,7 @@ enum TextSaveMethod {
 	 *   - File ownership can not be preserved.
 	 *   - File group can not be preserved.
 	 *   - Directory permissions do not allow creation of a new file.
-	 *   - POSXI ACL can not be preserved (if enabled).
+	 *   - POSIX ACL can not be preserved (if enabled).
 	 *   - SELinux security context can not be preserved (if enabled).
 	 * @endrst
 	 */
@@ -362,7 +362,7 @@ bool text_saveat_method(Text*, int dirfd, const char *filename, enum TextSaveMet
  * Setup a sequence of write operations.
  *
  * The returned ``TextSave`` pointer can be used to write multiple, possibly
- * non-contigious, file ranges.
+ * non-contiguous, file ranges.
  * @rst
  * .. warning:: For every call to ``text_save_begin`` there must be exactly
  *              one matching call to either ``text_save_commit`` or

--- a/ui.h
+++ b/ui.h
@@ -7,7 +7,7 @@
 
 /* enable large file optimization for files larger than: */
 #define UI_LARGE_FILE_SIZE (1 << 25)
-/* enable large file optimization fo files containing lines longer than: */
+/* enable large file optimization for files containing lines longer than: */
 #define UI_LARGE_FILE_LINE_SIZE (1 << 16)
 
 typedef struct Ui Ui;

--- a/view.c
+++ b/view.c
@@ -358,7 +358,7 @@ void view_draw(View *view) {
 			cell = (Cell){ .data = "\xEF\xBF\xBD", .len = len, .width = 1 };
 		} else if (len == (size_t)-2) {
 			/* not enough bytes available to convert to a
-			 * wide character. advance file position and read
+			 * wide character. Advance file position and read
 			 * another junk into buffer.
 			 */
 			rem = text_bytes_get(view->text, pos+prev_cell.len, size, text);

--- a/view.h
+++ b/view.h
@@ -58,11 +58,11 @@ Filerange view_viewport_get(View*);
  * @param pos The position to query.
  * @param line Will be updated with screen line on which ``pos`` resides.
  * @param row Will be updaded with zero based window row on which ``pos`` resides.
- * @param col Will be updated with zero based window column which ``pos`` resides.
+ * @param col Will be updated with zero based window column on which ``pos`` resides.
  * @return Whether ``pos`` is visible. If not, the pointer arguments are left unmodified.
  */
 bool view_coord_get(View*, size_t pos, Line **line, int *row, int *col);
-/** Get position at the start ot the ``n``-th window line, counting from 1. */
+/** Get position at the start of the ``n``-th window line, counting from 1. */
 size_t view_screenline_goto(View*, int n);
 /** Get first screen line. */
 Line *view_lines_first(View*);
@@ -122,7 +122,7 @@ Selection *view_selections_new_force(View*, size_t pos);
 /**
  * Dispose an existing selection.
  * @rst
- * .. warning:: Not applicaple for the last existing selection.
+ * .. warning:: Not applicable for the last existing selection.
  * @endrst
  */
 bool view_selections_dispose(Selection*);
@@ -138,7 +138,7 @@ bool view_selections_dispose_force(Selection*);
  * Query state of primary selection.
  *
  * If the primary selection was marked for destruction, return it and
- * clear descruction flag.
+ * clear destruction flag.
  */
 Selection *view_selection_disposed(View*);
 /** Dispose all but the primary selection. */
@@ -324,7 +324,7 @@ size_t view_screenline_end(Selection*);
  */
 /**
  * Move primary selection cursor to the given position.
- * Makes sure that position is visisble.
+ * Makes sure that position is visible.
  * @rst
  * .. note:: If position was not visible before, we attempt to show
  *           surrounding context. The viewport will be adjusted such

--- a/vis-core.h
+++ b/vis-core.h
@@ -14,7 +14,7 @@
 
 /* a mode contains a set of key bindings which are currently valid.
  *
- * each mode can specify one parent mode which is consultated if a given key
+ * each mode can specify one parent mode which is consulted if a given key
  * is not found in the current mode. hence the modes form a tree which is
  * searched from the current mode up towards the root mode until a valid binding
  * is found.
@@ -63,13 +63,13 @@ struct OperatorContext {
 };
 
 typedef struct {
-	/* operator logic, returns new cursor position, if EPOS is
+	/* operator logic, returns new cursor position, if EPOS
 	 * the cursor is disposed (except if it is the primary one) */
 	VisOperatorFunction *func;
 	void *context;
 } Operator;
 
-typedef struct { /* Motion implementation, takes a cursor postion and returns a new one */
+typedef struct { /* Motion implementation, takes a cursor position and returns a new one */
 	/* TODO: merge types / use union to save space */
 	size_t (*cur)(Selection*);
 	size_t (*txt)(Text*, size_t pos);
@@ -154,7 +154,7 @@ struct File { /* shared state among windows displaying the same file */
 };
 
 struct Win {
-	Vis *vis;               /* editor instance to which this window belongs to */
+	Vis *vis;               /* editor instance to which this window belongs */
 	UiWin *ui;              /* ui object handling visual appearance of this window */
 	File *file;             /* file being displayed in this window */
 	View *view;             /* currently displayed part of underlying text */
@@ -167,7 +167,7 @@ struct Win {
 };
 
 struct Vis {
-	Ui *ui;                              /* user interface repsonsible for visual appearance */
+	Ui *ui;                              /* user interface responsible for visual appearance */
 	File *files;                         /* all files currently managed by this editor instance */
 	File *command_file;                  /* special internal file used to store :-command prompt */
 	File *search_file;                   /* special internal file used to store /,? search prompt */
@@ -201,20 +201,20 @@ struct Vis {
 	Action action;                       /* current action which is in progress */
 	Action action_prev;                  /* last operator action used by the repeat (dot) command */
 	Mode *mode;                          /* currently active mode, used to search for keybindings */
-	Mode *mode_prev;                     /* previsouly active user mode */
+	Mode *mode_prev;                     /* previously active user mode */
 	bool initialized;                    /* whether UI and Lua integration has been initialized */
 	int nesting_level;                   /* parsing state to hold keep track of { } nesting level */
 	volatile bool running;               /* exit main loop once this becomes false */
 	int exit_status;                     /* exit status when terminating main loop */
 	volatile sig_atomic_t interrupted;   /* abort command (SIGINT occured) */
-	volatile sig_atomic_t sigbus;        /* one of the memory mapped region became unavailable (SIGBUS) */
+	volatile sig_atomic_t sigbus;        /* one of the memory mapped regions became unavailable (SIGBUS) */
 	volatile sig_atomic_t need_resize;   /* need to resize UI (SIGWINCH occured) */
 	volatile sig_atomic_t resume;        /* need to resume UI (SIGCONT occured) */
 	volatile sig_atomic_t terminate;     /* need to terminate we were being killed by SIGTERM */
 	sigjmp_buf sigbus_jmpbuf;            /* used to jump back to a known good state in the mainloop after (SIGBUS) */
 	Map *actions;                        /* registered editor actions / special keys commands */
 	Array actions_user;                  /* dynamically allocated editor actions */
-	lua_State *lua;                      /* lua context used for syntax highligthing */
+	lua_State *lua;                      /* lua context used for syntax highlighting */
 	enum TextLoadMethod load_method;     /* how existing files should be loaded */
 	VisEvent *event;
 	Array operators;
@@ -248,7 +248,7 @@ typedef struct {
 
 typedef MarkDef RegisterDef;
 
-/** stuff used by multiple of the vis-* files */
+/** stuff used by several of the vis-* files */
 
 extern Mode vis_modes[VIS_MODE_INVALID];
 extern const Movement vis_motions[VIS_MOVE_INVALID];

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -331,7 +331,7 @@ const char *obj_type_get(lua_State *L) {
 	lua_getfield(L, LUA_REGISTRYINDEX, "vis.types");
 	lua_getmetatable(L, -2);
 	lua_gettable(L, -2);
-	// XXX: in theory string might become invalid when poped from stack
+	// XXX: in theory string might become invalid when popped from stack
 	const char *type = lua_tostring(L, -1);
 	lua_pop(L, 2);
 	return type;
@@ -758,7 +758,7 @@ static int command(lua_State *L) {
  * Display a short message.
  *
  * The single line message will be displayed at the bottom of
- * the scren and automatically hidden once a key is pressed.
+ * the screen and automatically hidden once a key is pressed.
  *
  * @function info
  * @tparam string message the message to display
@@ -1309,7 +1309,7 @@ static int replace(lua_State *L) {
  * eventually hands over control to the editor core. The exit status
  * of the most recent call is used.
  *
- * All unsaved chanes will be lost!
+ * All unsaved changes will be lost!
  *
  * @function exit
  * @tparam int code the exit status returned to the operating system
@@ -2912,7 +2912,7 @@ void vis_lua_quit(Vis *vis) {
  * Input key event in either input or replace mode.
  * @function input
  * @tparam string key
- * @treturn bool whether the key was cosumed or not
+ * @treturn bool whether the key was consumed or not
  */
 static bool vis_lua_input(Vis *vis, const char *key, size_t len) {
 	lua_State *L = vis->lua;

--- a/vis.c
+++ b/vis.c
@@ -1018,7 +1018,7 @@ void vis_do(Vis *vis) {
 			register_resize(reg, last_reg_slot+1);
 		}
 
-		/* we do not support visual repeat, still do something resonable */
+		/* we do not support visual repeat, still do something reasonable */
 		if (vis->mode->visual && !a->movement && !a->textobj)
 			a->movement = &vis_motions[VIS_MOVE_NOP];
 
@@ -1686,7 +1686,7 @@ void vis_insert_nl(Vis *vis) {
 		size_t newpos = vis_text_insert_nl(vis, txt, pos);
 		/* This is a bit of a hack to fix cursor positioning when
 		 * inserting a new line at the start of the view port.
-		 * It has the effect of reseting the mark used by the view
+		 * It has the effect of resetting the mark used by the view
 		 * code to keep track of the start of the visible region.
 		 */
 		view_cursors_to(s, pos);

--- a/vis.h
+++ b/vis.h
@@ -77,7 +77,7 @@ typedef union {
  * @rst
  * .. note:: An empty string ``""`` indicates that no further input is available.
  * @endrst
- * @return Pointer to first non-cosumed key.
+ * @return Pointer to first non-consumed key.
  * @rst
  * .. warning:: Must be in range ``[keys, keys+strlen(keys)]`` or ``NULL`` to
  *              indicate that not enough input was available. In the latter case
@@ -131,7 +131,7 @@ void vis_exit(Vis*, int status);
 void vis_die(Vis*, const char *msg, ...) __attribute__((noreturn,format(printf, 2, 3)));
 
 /**
- * Temporarily supsend the editor process.
+ * Temporarily suspend the editor process.
  * @rst
  * .. note:: This function will generate a ``SIGTSTP`` signal.
  * @endrst
@@ -222,9 +222,9 @@ void vis_window_prev(Vis*);
 void vis_window_focus(Win*);
 /** Swap location of two windows. */
 void vis_window_swap(Win*, Win*);
-/** Query window dimension. */
+/** Query window width. */
 int vis_window_width_get(const Win*);
-/** Query window dimension. */
+/** Query window height. */
 int vis_window_height_get(const Win*);
 /**
  * @}
@@ -264,7 +264,7 @@ void vis_replace(Vis*, size_t pos, const char *data, size_t len);
 /** Perform insertion at all cursor positions. */
 void vis_insert_key(Vis*, const char *data, size_t len);
 /**
- * Perform character subsitution at all cursor positions.
+ * Perform character substitution at all cursor positions.
  * @rst
  * .. note:: Does not replace new line characters.
  * @endrst
@@ -433,7 +433,7 @@ int vis_operator_register(Vis*, VisOperatorFunction*, void *context);
  *
  *  - `VIS_OP_JOIN`       a char pointer referring to the text to insert between lines.
  *  - `VIS_OP_MODESWITCH` an ``enum VisMode`` indicating the mode to switch to.
- *  - `VIS_OP_REPLACE`    a char pointer reffering to the replacement character.
+ *  - `VIS_OP_REPLACE`    a char pointer referring to the replacement character.
  */
 bool vis_operator(Vis*, enum VisOperator, ...);
 
@@ -774,7 +774,7 @@ enum VisRegister vis_register_used(Vis*);
  * Get register content.
  * @return An array of ``TextString`` structs.
  * @rst
- * .. warning:: The caller must eventually free the array ressources using
+ * .. warning:: The caller must eventually free the array resources using
  *              ``array_release``.
  * @endrst
  */
@@ -853,7 +853,7 @@ enum VisOption {
  * Option handler function.
  * @param win The window to which option should apply, might be ``NULL``.
  * @param context User provided context pointer as given to `vis_option_register`.
- * @param force Whether the option was specfied with a bang ``!``.
+ * @param force Whether the option was specified with a bang ``!``.
  * @param name Name of option which was set.
  * @param arg The new option value.
  */
@@ -964,7 +964,7 @@ void vis_keys_feed(Vis*, const char *keys);
 Regex *vis_regex(Vis*, const char *pattern);
 
 /**
- * Take an undo snaphost to which we can later revert to.
+ * Take an undo snapshot to which we can later revert.
  * @rst
  * .. note:: Does nothing when invoked while replaying a macro.
  * @endrst


### PR DESCRIPTION
This pull request fixes typos in comments that I spotted reading through the code.