### PR TITLE
vis-open: allow to show files vertically

### DIFF
--- a/vis-open
+++ b/vis-open
@@ -5,6 +5,10 @@ set -e
 NL='
 '
 
+if [ -z "$VIS_OPEN_LINES" ]; then
+	VIS_OPEN_LINES='0'
+fi
+
 VIS_MENU_PROMPT=''
 ALLOW_AUTO_SELECT='1'
 
@@ -66,7 +70,7 @@ fi
 
 # At this point, we have a bunch of options we need to present to the
 # user so they can pick one.
-CHOICE="$(printf '%s\n' '..' "$@" | wrap_dirs | vis-menu -b -p "$VIS_MENU_PROMPT")"
+CHOICE="$(printf '%s\n' '..' "$@" | wrap_dirs | vis-menu -b -l "$VIS_OPEN_LINES" -p "$VIS_MENU_PROMPT")"
 
 # Did they pick a file or directory? Who knows, let's let the next iteration figure it out.
 exec "$0" -p "$VIS_MENU_PROMPT" -- "$CHOICE"


### PR DESCRIPTION
It might be more comfortable to navigate through the files
arranged vertically.

Add ability to specify VIS_OPEN_LINES environment variable
which is passed to vis-menu as -l option.

It would be better to add vis option for this to set it
via lua config, but it might be added later.

Signed-off-by: Vadym Kochan <vadim4j@gmail.com>