### PR TITLE
Luacheck fixes

### DIFF
--- a/lua/plugins/complete-filename.lua
+++ b/lua/plugins/complete-filename.lua
@@ -13,8 +13,8 @@ vis:map(vis.modes.INSERT, "<C-x><C-f>", function()
 	local prefix = file:content(range)
 	if not prefix then return end
 	-- Strip leading delimiters for some languages
-	i, j = string.find(prefix, "[[(<'\"]+")
-	if j then prefix = prefix:sub(j + 1) end
+	local i, j = string.find(prefix, "[[(<'\"]+")
+	if i then prefix = prefix:sub(j + 1) end
 	local cmd = string.format("vis-complete --file '%s'", prefix:gsub("'", "'\\''"))
 	local status, out, err = vis:pipe(file, { start = 0, finish = 0 }, cmd)
 	if status ~= 0 or not out then

--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -352,9 +352,11 @@ vis.ftdetect.filetypes = {
 	},
 	routeros = {
 		ext = { "%.rsc" },
+    -- luacheck: push ignore 212
 		detect = function(file, data)
 			return data:match("^#.* by RouterOS")
 		end
+    -- luacheck: pop
 	},
 	rstats = {
 		ext = { "%.R$", "%.Rout$", "%.Rhistory$", "%.Rt$", "Rout.save", "Rout.fail" },
@@ -394,9 +396,11 @@ vis.ftdetect.filetypes = {
 		ext = { "%.ddl$", "%.sql$" },
 	},
 	strace = {
+    -- luacheck: push ignore 212
 		detect = function(file, data)
 			return data:match("^execve%(")
 		end
+    -- luacheck: pop
 	},
 	systemd = {
 		ext = {

--- a/lua/vis.lua
+++ b/lua/vis.lua
@@ -98,6 +98,7 @@ vis.textobject_new = function(vis, key, textobject, help)
 	return true
 end
 
+-- luacheck: push ignore 212
 --- Check whether a Lua module exists
 --
 -- Checks whether a subsequent @{require} call will succeed.
@@ -112,6 +113,7 @@ vis.module_exist = function(vis, name)
 	end
 	return false
 end
+-- luacheck: pop
 
 vis.lexers = {}
 

--- a/lua/visrc.lua
+++ b/lua/visrc.lua
@@ -5,7 +5,9 @@ vis.events.subscribe(vis.events.INIT, function()
 	-- Your global configuration options
 end)
 
+-- luacheck: push ignore 212
 vis.events.subscribe(vis.events.WIN_OPEN, function(win)
 	-- Your per window configuration options e.g.
 	-- vis:command('set number')
 end)
+-- luacheck: pop


### PR DESCRIPTION
Running `make luacheck` showed what seem to be two potential bugs. I think I managed to fix the first one in the first commit. How to fix the second one isn't clear. The warning is as follows:

`
Checking lua/plugins/filetype.lua                 1 warning

    lua/plugins/filetype.lua:542:6: accessing undefined variable mime
`

To me this warning triggered by this [line](https://github.com/martanne/vis/blob/master/lua/plugins/filetype.lua#L538) indeed looks like this part of the code wouldn't pick up the mime variable from the defined file-extensions, so I don't think this is a false positive. Unfortunately not at all clear to me how to fix this one. 

While there I also silenced the "unused argument warnings" as one can't pass ignore values to `make luacheck` and not returning false positives is probably the better approach seeing that the developer documentation recommends to run make luacheck [here](https://github.com/martanne/vis/wiki/Developer-Overview#luacheck). 