### PR TITLE
filetype: Add recognition for APKBUILD, .ebuild, and general Makefile shebang (debian/rules).

### DIFF
--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -40,7 +40,7 @@ vis.ftdetect.filetypes = {
 		ext = { "%.awk$" },
 	},
 	bash = {
-		ext = { "%.bash$", "%.csh$", "%.sh$", "%.zsh$" },
+		ext = { "%.bash$", "%.csh$", "%.sh$", "%.zsh$" ,"^APKBUILD$", "%.ebuild$"},
 		mime = { "text/x-shellscript", "application/x-shellscript" },
 	},
 	batch = {

--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -250,6 +250,9 @@ vis.ftdetect.filetypes = {
 	makefile = {
 		ext = { "%.iface$", "%.mak$", "%.mk$", "GNUmakefile", "makefile", "Makefile" },
 		mime = { "text/x-makefile" },
+		detect = function(_, data)
+			return data:match("^#!/usr/bin/make")
+		end
 	},
 	man = {
 		ext = {


### PR DESCRIPTION
These two commits add support for APKBUILD, .ebuild, and generic Makefile (with shebang) files in the filetype plugin.