### PR TITLE
ui: add bell notification (beep)

### DIFF
--- a/main.c
+++ b/main.c
@@ -1875,7 +1875,7 @@ static const char *mark(Vis *vis, const char *keys, const Arg *arg) {
 
 static const char *undo(Vis *vis, const char *keys, const Arg *arg) {
 	size_t pos = text_undo(vis_text(vis));
-	if (pos != EPOS) {
+	if (vis_verify_cursor(vis, pos)) {
 		View *view = vis_view(vis);
 		if (view_selections_count(view) == 1)
 			view_cursor_to(view, pos);
@@ -1887,7 +1887,7 @@ static const char *undo(Vis *vis, const char *keys, const Arg *arg) {
 
 static const char *redo(Vis *vis, const char *keys, const Arg *arg) {
 	size_t pos = text_redo(vis_text(vis));
-	if (pos != EPOS) {
+	if (vis_verify_cursor(vis, pos)) {
 		View *view = vis_view(vis);
 		if (view_selections_count(view) == 1)
 			view_cursor_to(view, pos);
@@ -1902,7 +1902,7 @@ static const char *earlier(Vis *vis, const char *keys, const Arg *arg) {
 	VisCountIterator it = vis_count_iterator_get(vis, 1);
 	while (vis_count_iterator_next(&it))
 		pos = text_earlier(vis_text(vis));
-	if (pos != EPOS) {
+	if (vis_verify_cursor(vis, pos)) {
 		view_cursor_to(vis_view(vis), pos);
 		/* redraw all windows in case some display the same file */
 		vis_draw(vis);
@@ -1915,7 +1915,7 @@ static const char *later(Vis *vis, const char *keys, const Arg *arg) {
 	VisCountIterator it = vis_count_iterator_get(vis, 1);
 	while (vis_count_iterator_next(&it))
 		pos = text_later(vis_text(vis));
-	if (pos != EPOS) {
+	if (vis_verify_cursor(vis, pos)) {
 		view_cursor_to(vis_view(vis), pos);
 		/* redraw all windows in case some display the same file */
 		vis_draw(vis);

--- a/ui-terminal-vt100.c
+++ b/ui-terminal-vt100.c
@@ -43,6 +43,7 @@
 
 #define ui_term_backend_init ui_vt100_init
 #define ui_term_backend_blit ui_vt100_blit
+#define ui_term_backend_bell ui_vt100_bell
 #define ui_term_backend_clear ui_vt100_clear
 #define ui_term_backend_colors ui_vt100_colors
 #define ui_term_backend_resize ui_vt100_resize
@@ -164,6 +165,10 @@ static void ui_vt100_blit(UiTerm *tui) {
 		}
 	}
 	output(buffer_content(buf), buffer_length0(buf));
+}
+
+static void ui_vt100_bell(UiTerm *tui) {
+	output_literal("\a");
 }
 
 static void ui_vt100_clear(UiTerm *tui) { }

--- a/ui-terminal.c
+++ b/ui-terminal.c
@@ -85,6 +85,11 @@ __attribute__((noreturn)) static void ui_die_msg(Ui *ui, const char *msg, ...) {
 	va_end(ap);
 }
 
+static void ui_bell(Ui *ui) {
+	UiTerm *tui = (UiTerm*)ui;
+	ui_term_backend_bell(tui);
+}
+
 static void ui_window_resize(UiTermWin *win, int width, int height) {
 	debug("ui-win-resize[%s]: %dx%d\n", win->win->file->name ? win->win->file->name : "noname", width, height);
 	bool status = win->options & UI_OPTION_STATUSBAR;
@@ -711,6 +716,7 @@ Ui *ui_term_new(void) {
 		.draw = ui_draw,
 		.redraw = ui_redraw,
 		.arrange = ui_arrange,
+		.bell = ui_bell,
 		.doupdates = ui_doupdates,
 		.die = ui_die,
 		.info = ui_info,

--- a/ui.h
+++ b/ui.h
@@ -98,6 +98,7 @@ struct Ui {
 	void (*redraw)(Ui*);
 	void (*suspend)(Ui*);
 	void (*resume)(Ui*);
+	void (*bell)(Ui*);
 	void (*doupdates)(Ui*, bool);
 	bool (*getkey)(Ui*, TermKeyKey*);
 	void (*terminal_save)(Ui*, bool fscr);

--- a/vis.c
+++ b/vis.c
@@ -2013,6 +2013,14 @@ void vis_file_snapshot(Vis *vis, File *file) {
 		text_snapshot(file->text);
 }
 
+bool vis_verify_cursor(Vis *vis, const size_t pos) {
+	if (pos == EPOS) {
+		vis->ui->bell(vis->ui);
+		return false;
+	}
+	return true;
+}
+
 Text *vis_text(Vis *vis) {
 	Win *win = vis->win;
 	return win ? win->file->text : NULL;

--- a/vis.h
+++ b/vis.h
@@ -987,6 +987,12 @@ Regex *vis_regex(Vis*, const char *pattern);
  * @endrst
  */
 void vis_file_snapshot(Vis*, File*);
+
+/**
+ * Sound the bell and return ``false`` when the cursor position equals ``EPOS``
+ * and should thus be discarded.
+ */
+bool vis_verify_cursor(Vis*, const size_t pos);
 /** @} */
 
 /* TODO: expose proper API to iterate through files etc */


### PR DESCRIPTION
The bell is sounded when there is nothing to undo/redo.
This is consistent with vim, although vim has many more beeps cases.

---
I wanted to browse the vis code-base a bit and decided that this was a good excuse to do so.
In VIM, the bell can be silenced by configuring a "visual bell" (screen flash) and setting the visual bell command to the empty string. I reckon implementing anything like a "visual bell" is out of scope for vis (it can be configured in your terminal emulator anyway), but we might want an option to silence the bell still.