### PR TITLE
Soft word wrapping

### DIFF
--- a/man/vis.1
+++ b/man/vis.1
@@ -1433,6 +1433,11 @@ WARNING: modifying a memory mapped file in-place will cause data loss.
 Whether to use vertical or horizontal layout.
 .It Cm ignorecase , Cm ic Op Cm off
 Whether to ignore case when searching.
+.It Ic wrapcolumn , Ic wc Op Ar 0
+Wrap lines at minimum of window width and wrapcolumn.
+.
+.It Ic breakat , brk Op Dq Pa ""
+Characters which might cause a word wrap.
 .El
 .
 .Sh COMMAND and SEARCH PROMPT

--- a/sam.c
+++ b/sam.c
@@ -301,6 +301,8 @@ enum {
 	OPTION_CHANGE_256COLORS,
 	OPTION_LAYOUT,
 	OPTION_IGNORECASE,
+	OPTION_BREAKAT,
+	OPTION_WRAP_COLUMN,
 };
 
 static const OptionDef options[] = {
@@ -393,6 +395,16 @@ static const OptionDef options[] = {
 		{ "ignorecase", "ic" },
 		VIS_OPTION_TYPE_BOOL,
 		VIS_HELP("Ignore case when searching")
+	},
+	[OPTION_BREAKAT] = {
+		{ "breakat", "brk" },
+		VIS_OPTION_TYPE_STRING|VIS_OPTION_NEED_WINDOW,
+		VIS_HELP("Characters which might cause a word wrap")
+	},
+	[OPTION_WRAP_COLUMN] = {
+		{ "wrapcolumn", "wc" },
+		VIS_OPTION_TYPE_NUMBER|VIS_OPTION_NEED_WINDOW,
+		VIS_HELP("Wrap lines at minimum of window width and wrapcolumn")
 	},
 };
 

--- a/view.h
+++ b/view.h
@@ -358,6 +358,8 @@ void view_options_set(View*, enum UiOption options);
 enum UiOption view_options_get(View*);
 void view_colorcolumn_set(View*, int col);
 int view_colorcolumn_get(View*);
+void view_wrapcolumn_set(View*, int col);
+bool view_breakat_set(View*, const char *breakat);
 
 /** Set how many spaces are used to display a tab `\t` character. */
 void view_tabwidth_set(View*, int tabwidth);

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -364,6 +364,15 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 	case OPTION_IGNORECASE:
 		vis->ignorecase = toggle ? !vis->ignorecase : arg.b;
 		break;
+	case OPTION_BREAKAT:
+		if (!view_breakat_set(win->view, arg.s)) {
+			vis_info_show(vis, "Failed to set breakat");
+			return false;
+		}
+		break;
+	case OPTION_WRAP_COLUMN:
+		view_wrapcolumn_set(win->view, arg.i);
+		break;
 	default:
 		if (!opt->func)
 			return false;


### PR DESCRIPTION
Hello, this pull request adds soft word wrapping (`linebreak` in vim) support to vis. In addition, it defines an option to change the visual line length instead of always using window width for the maximum line length. The latter was made trivial by my code rewrite.

#### Rationale

It is a lot of pain to write LaTeX and Markdown documents without proper word wrapping support in the editor. This option is something that makes your life much easier and is supported by nearly all other text editors. In fact, a similar functionality was requested by #142, but on the contrary to that proposal, this pull request only affects the way lines are displayed on screen and doesn't modify the underlined character data.

#### New options

- `breakat / brk` specifies a list of characters after which the editor may decide to wrap the line before window width is reached. The default value for this option is an empty string which corresponds to the old behavior of vis. In this case, cells are just printed one after another until window width is reached.
- `wrapcolumn / wc` affects the maximum displayed line length and is especially useful for large monitors. Zero is the default for this option and thus disables this feature. I didn't exactly know how to name this option, but "wrapcolumn" sounds pretty good to me.

I have included a little screenshot with both of the new options enabled below.

```
:set wrapcolumn 80
:set breakat ' .!?'
```

![vis_word_wrap](https://user-images.githubusercontent.com/69064459/117587029-1ede0700-b11c-11eb-93c8-0641a65c29c5.png)

#### Todo

- I have tried this feature with a couple of different text files and couldn't see any problems with my implementation. However, feel free to test this pull request on some strange edge cases, which may cause something to break. Anyway, my intention was to not change the default look of vis, but I had to rewrite the view_addch function in *view.c*, which may have caused some unintentional side effects.
- ~~Right now, `breakat` only supports ASCII characters, but it shouldn't be too difficult to extend my code to handle any UTF-8 characters. In fact, vim implementation of `breakat` also only supports ASCII.~~
