### PR TITLE
reword the :[v]split and :[v]new descriptions in vis.1

### DIFF
--- a/.github/workflows/man.yml
+++ b/.github/workflows/man.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Manual generation
       run: |
         make man
-        wget 'https://cvsweb.bsd.lv/~checkout~/mandoc/mandoc.css?rev=1.46&content-type=text/plain' -O man/mandoc.css
+        wget -O - https://mandoc.bsd.lv/snapshots/mandoc-1.14.6.tar.gz | tar -zxC man --strip-components 1 mandoc-1.14.6/mandoc.css
         ln -sf "${GITHUB_REPOSITORY#$GITHUB_ACTOR/}.1.html" man/index.html
 
     - name: Upload

--- a/man/vis.1
+++ b/man/vis.1
@@ -1189,8 +1189,8 @@ Any unique prefix can be used to abbreviate a command.
 A file must be opened in at least one window.
 If the last window displaying a certain file is closed all unsaved changes are
 discarded.
-Windows are equally sized and can be displayed in either horizontal or vertical
-fashion.
+Windows are equally sized and can be displayed in rows (horizontally)
+or in columns (vertically).
 The
 .Aq Ic C-w
 .Ic h ,
@@ -1204,19 +1204,19 @@ and
 key mappings can be used to switch between windows.
 .Bl -tag -width indent
 .It Ic :new
-open an empty window, arrange horizontally
+open an empty window, arranged as a new row (horizontally)
 .
 .It Ic :vnew
-open an empty window, arrange vertically
+open an empty window, arranged as a new column (vertically)
 .
 .It Ic :open Ns Oo Cm \&! Oc Op Ar file name
 open a new window, displaying file name if given
 .
 .It Ic :split Op Ar file name
-split window horizontally
+split window into rows (horizontally)
 .
 .It Ic :vsplit Op Ar file name
-split window vertically
+split window into columns (vertically)
 .
 .It Ic :q Ns Oo Cm \&! Oc Op Ar exit code
 close currently focused window


### PR DESCRIPTION
I've always found this wording a bit confusing.  I think the way I understand it in my mind is opposite to the current wording. By switching to rows and columns it should clear up the confusion.

(horizontally) and (vertically) were kept to be consistent with the 'v'
mnemonic and with the enum labels in the code.