### PR TITLE
lexers/html: detect script type "module"

### DIFF
--- a/lua/lexers/html.lua
+++ b/lua/lexers/html.lua
@@ -136,7 +136,8 @@ local js = l.load('javascript')
 local script_element = word_match({'script'}, nil, case_insensitive_tags)
 local js_start_rule = #(P('<') * script_element *
                        ('>' + P(function(input, index)
-  if input:find('^%s+type%s*=%s*(["\'])text/javascript%1', index) then
+  if input:find('^%s+type%s*=%s*(["\'])text/javascript%1', index) or
+     input:find('^%s+type%s*=%s*(["\']?)module%1', index) then
     return index
   end
 end))) * M.embed_start_tag -- <script type="text/javascript">


### PR DESCRIPTION
In theory it could be `<script type=module>` (without quotes), hence `(["\']?)`.
Edit: Hmm, `(["\']?)` doesn't seem to work (for unquoted, quoted is fine).

So maybe something like this would be better:
```lua
  local _, _, _, script_type = input:find('^%s+type%s*=%s*(["\'])(^["\']+)%1', index)
  if script_type == 'text/javascript' or script_type == 'module' then
```