### PR TITLE
Add a theming option for dimmed text

### DIFF
--- a/ui-terminal-curses.c
+++ b/ui-terminal-curses.c
@@ -35,6 +35,7 @@
 #define CELL_ATTR_BLINK     A_BLINK
 #define CELL_ATTR_BOLD      A_BOLD
 #define CELL_ATTR_ITALIC    A_ITALIC
+#define CELL_ATTR_DIM       A_DIM
 
 #ifdef NCURSES_VERSION
 # ifndef NCURSES_EXT_COLORS

--- a/ui-terminal-vt100.c
+++ b/ui-terminal-vt100.c
@@ -69,6 +69,7 @@
 #define CELL_ATTR_BLINK     (1 << 2)
 #define CELL_ATTR_BOLD      (1 << 3)
 #define CELL_ATTR_ITALIC    (1 << 4)
+#define CELL_ATTR_DIM       (1 << 5)
 
 typedef struct {
 	UiTerm uiterm;
@@ -120,6 +121,7 @@ static void ui_vt100_blit(UiTerm *tui) {
 					char on[4], off[4];
 				} cell_attrs[] = {
 					{ CELL_ATTR_BOLD, "1", "22" },
+					{ CELL_ATTR_DIM, "2", "22" },
 					{ CELL_ATTR_ITALIC, "3", "23" },
 					{ CELL_ATTR_UNDERLINE, "4", "24" },
 					{ CELL_ATTR_BLINK, "5", "25" },

--- a/ui-terminal.c
+++ b/ui-terminal.c
@@ -170,6 +170,10 @@ static bool ui_style_define(UiWin *w, int id, const char *style) {
 			cell_style.attr |= CELL_ATTR_BOLD;
 		} else if (!strcasecmp(option, "notbold")) {
 			cell_style.attr &= ~CELL_ATTR_BOLD;
+		} else if (!strcasecmp(option, "dim")) {
+			cell_style.attr |= CELL_ATTR_DIM;
+		} else if (!strcasecmp(option, "notdim")) {
+			cell_style.attr &= ~CELL_ATTR_DIM;
 		} else if (!strcasecmp(option, "italics")) {
 			cell_style.attr |= CELL_ATTR_ITALIC;
 		} else if (!strcasecmp(option, "notitalics")) {


### PR DESCRIPTION
This small patch adds a new theming keyword: `[not]dim`, and equips vis to handle it in both the curses backend and the hand rolled vt-100 backend