### PR TITLE
lexers/makefile: Support multiple targets in a single definition

### DIFF
--- a/lua/lexers/makefile.lua
+++ b/lua/lexers/makefile.lua
@@ -72,7 +72,8 @@ local special_target = token(l.CONSTANT, l.word_match({
   '.SILENT', '.EXPORT_ALL_VARIABLES', '.NOTPARALLEL', '.ONESHELL', '.POSIX'
 }, '.'))
 local normal_target = token('target', (l.any - l.space - S(':#='))^1)
-local target = l.starts_line((special_target + normal_target) * ws^0 *
+local target_list = normal_target * (ws * normal_target)^0
+local target = l.starts_line((special_target + target_list) * ws^0 *
                              #(':' * -P('=')))
 
 -- Identifiers.


### PR DESCRIPTION
Multiple targets are supported by POSIX standard and most commonly used make implementations. I was mildly annoyed by them not being coloured so I fixed it and decided to share it.
This does *not* introduce support for [grouped targets](https://www.gnu.org/software/make/manual/html_node/Multiple-Targets.html#Rules-with-Grouped-Targets). If that's desirable, it should be straight-forward to do.