### PR TITLE
filetype: Set `diff` filetype for `COMMIT_EDITMSG` files

### DIFF
--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -96,7 +96,8 @@ vis.ftdetect.filetypes = {
 		ext = { "%.desktop$" },
 	},
 	diff = {
-		ext = { "%.diff$", "%.patch$", "%.rej$" },
+		ext = { "%.diff$", "%.patch$", "%.rej$", "^COMMIT_EDITMSG$" },
+		cmd = { "set colorcolumn 72" },
 	},
 	dmd = {
 		ext = { "%.d$", "%.di$" },
@@ -158,10 +159,6 @@ vis.ftdetect.filetypes = {
 	},
 	gherkin = {
 		ext = { "%.feature$" },
-	},
-	['git-commit'] = {
-		ext = { "^COMMIT_EDITMSG$" },
-		cmd = { "set colorcolumn 72" },
 	},
 	['git-rebase'] = {
 		ext = { "git%-rebase%-todo" },


### PR DESCRIPTION
This filename is set when writing a commit message in git.

If you run git-commit with an `--verbose` option or if you just have set it in your git-config, that shows you the patch diff on bottom of the file.

Unfortunately, now every patch file will set colorcolumn, but overall I think this is better than having duplicated lexers.