### PR TITLE
Redirect stderr of wl-copy to /dev/null

### DIFF
--- a/vis-clipboard
+++ b/vis-clipboard
@@ -81,9 +81,9 @@ vc_paste() {
 
 vc_wlclipboard_copy() {
 	if [ "$sel" = "primary" ]; then
-		wl-copy --primary -t TEXT
+		wl-copy --primary -t TEXT 2>/dev/null
 	else
-		wl-copy -t TEXT
+		wl-copy -t TEXT 2>/dev/null
 	fi
 }
 


### PR DESCRIPTION
Fixes #929.
This of course ignores possible error messages from wl-copy.
Still, the system clipboard on wayland does not work without this change.