### PR TITLE
filetype: Allow ".PKGBUILD" extension for PKGBUILDs

### DIFF
--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -308,7 +308,7 @@ vis.ftdetect.filetypes = {
 		ext = { "%.pike$", "%.pmod$" },
 	},
 	pkgbuild = {
-		ext = { "^PKGBUILD$" },
+		ext = { "^PKGBUILD$", "%.PKGBUILD$" },
 	},
 	pony = {
 		ext = { "%.pony$" },


### PR DESCRIPTION
Although this isn't standard, some AUR helpers use this (e.g. paru) and there is no real harm in adding it, so it might as well be included.