### PR TITLE
Re-enabled tre by #including <stddef.h>.

### DIFF
--- a/configure
+++ b/configure
@@ -380,6 +380,7 @@ if test "$tre" != "no" ; then
 	printf "checking for libtre... "
 
 cat > "$tmpc" <<EOF
+#include <stddef.h>
 #include <tre/tre.h>
 
 int main() {


### PR DESCRIPTION
I noticed libtre.so.5 was not linked to the vis binary; this fixes the test code in ./configure. I think this was caused by compilation on Void Linux's musl libc arch.

Love,

p