### PR TITLE
Fix Python MIME for filetype detection

### DIFF
--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -333,7 +333,7 @@ vis.ftdetect.filetypes = {
 	},
 	python = {
 		ext = { "%.sc$", "%.py$", "%.pyw$" },
-		mime = { "text/x-python" },
+		mime = { "text/x-python", "text/x-script.python" },
 	},
 	reason = {
 		ext = { "%.re$" },


### PR DESCRIPTION
On my machine (Linux, file 5.39), the MIME type `file` returns for Python files is `text/x-script.python`, not `text/x-python`.