### PR TITLE
Add filetype detection for SPEC file for RPM packages building.

### DIFF
--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -365,6 +365,9 @@ vis.ftdetect.filetypes = {
 			return data:match("^#.* by RouterOS")
 		end
 	},
+	rpmspec = {
+		ext = { "%.spec$" },
+	},
 	rstats = {
 		ext = { "%.R$", "%.Rout$", "%.Rhistory$", "%.Rt$", "Rout.save", "Rout.fail" },
 	},


### PR DESCRIPTION
Working on lexer for vis (which I will probably add to [scintillua](https://github.com/martanne/vis/tree/scintillua) branch), but I would like to add filetype first.