### PR TITLE
vis: Compare inodes instead of filenames

### DIFF
--- a/vis.c
+++ b/vis.c
@@ -179,14 +179,19 @@ err:
 
 static File *file_new(Vis *vis, const char *name) {
 	char *name_absolute = NULL;
+	struct stat new;
+
 	if (name) {
 		if (!(name_absolute = absolute_path(name)))
 			return NULL;
+		if (stat(name_absolute, &new) && errno != ENOENT)
+			return NULL;
+
 		File *existing = NULL;
-		/* try to detect whether the same file is already open in another window
-		 * TODO: do this based on inodes */
+		/* try to detect whether the same file is already open in another window */
 		for (File *file = vis->files; file; file = file->next) {
-			if (file->name && strcmp(file->name, name_absolute) == 0) {
+			if (file->name && file->stat.st_dev == new.st_dev &&
+				file->stat.st_ino == new.st_ino) {
 				existing = file;
 				break;
 			}

--- a/vis.h
+++ b/vis.h
@@ -189,8 +189,6 @@ void vis_update(Vis*);
  * @rst
  * .. note:: If the given file name is already opened in another window,
  *           the underlying File object is shared.
- * .. warning:: This duplication detection is currently based on normalized,
- *              absolute file names. TODO: compare inodes instead.
  * @endrst
  */
 bool vis_window_new(Vis*, const char *filename);


### PR DESCRIPTION
Hi,

This fixes a rather old TODO.

I'm unsure if the check for the return value of `stat(2)` should be done in an `if` statement, rather than in a simple `bool` variable. I chose the `if` statement out of personal preference.

Best Regards