### PR TITLE
vis: remove unused Arg union member

### DIFF
--- a/vis.h
+++ b/vis.h
@@ -68,7 +68,6 @@ typedef union {
 	const void *v;
 	void (*w)(View*);
 	void (*f)(Vis*);
-	Filerange (*combine)(const Filerange*, const Filerange*);
 } Arg;
 
 /**


### PR DESCRIPTION
This was missed when pairwise selection combinators were removed in 404bb95..d1d5853.