### PR TITLE
fix miscellaneous spelling mistakes

### DIFF
--- a/array.h
+++ b/array.h
@@ -33,14 +33,14 @@ typedef struct {
 } Array;
 
 /**
- * Initalize an Array object to store pointers.
+ * Initialize an Array object to store pointers.
  * @rst
  * .. note:: Is equivalent to ``array_init_sized(arr, sizeof(void*))``.
  * @endrst
  */
 void array_init(Array*);
 /**
- * Initalize an Array object to store arbitrarily sized objects.
+ * Initialize an Array object to store arbitrarily sized objects.
  */
 void array_init_sized(Array*, size_t elem_size);
 /** Initialize Array by using the same element size as in ``from``. */

--- a/buffer.h
+++ b/buffer.h
@@ -20,7 +20,7 @@ typedef struct {
 	size_t size;   /**< Maximal capacity of the buffer. */
 } Buffer;
 
-/** Initalize a Buffer object. */
+/** Initialize a Buffer object. */
 void buffer_init(Buffer*);
 /** Release all resources, reinitialize buffer. */
 void buffer_release(Buffer*);

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -554,7 +554,7 @@ INTERNAL_DOCS          = NO
 # names in lower-case letters. If set to YES, upper-case letters are also
 # allowed. This is useful if you have classes or files whose names only differ
 # in case and if your file system supports case sensitive file names. Windows
-# (including Cygwin) ands Mac users are advised to set this option to NO.
+# (including Cygwin) and Mac users are advised to set this option to NO.
 # The default value is: system dependent.
 
 CASE_SENSE_NAMES       = YES
@@ -1223,7 +1223,7 @@ HTML_EXTRA_FILES       =
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to
-# this color. Hue is specified as an angle on a colorwheel, see
+# this color. Hue is specified as an angle on a color wheel, see
 # https://en.wikipedia.org/wiki/Hue for more information. For instance the value
 # 0 represents red, 60 is yellow, 120 is green, 180 is cyan, 240 is blue, 300
 # purple, and 360 is red again.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,5 +1,5 @@
-Vis Editor API Documenation
-===========================
+Vis Editor API Documentation
+============================
 
 .. toctree::
    :maxdepth: 2

--- a/doc/text.rst
+++ b/doc/text.rst
@@ -105,7 +105,7 @@ A mark keeps track of a text position. Subsequent text changes will update
 all marks placed after the modification point. Reverting to an older text
 state will hide all affected marks, redoing the changes will restore them.
 
-.. warning:: Due to an optimization cached modifications (i.e. no ``text_snaphot``
+.. warning:: Due to an optimization cached modifications (i.e. no ``text_snapshot``
              was performed between setting the mark and issuing the changes) might
              not adjust mark positions accurately.
 

--- a/lua/lexers/README.md
+++ b/lua/lexers/README.md
@@ -25,7 +25,7 @@ where `<name>` corresponds to the filename without the `.lua` extension.
 # Adding new lexers
 
 To add a new lexer, start with the template quoted below or a lexer of a
-similiar language. Read the
+similar language. Read the
 [lexer module documentation](http://foicica.com/scintillua/api.html#lexer).
 The [LPeg](http://www.inf.puc-rio.br/~roberto/lpeg/) introduction might also
 be useful.

--- a/lua/lexers/lexer.lua
+++ b/lua/lexers/lexer.lua
@@ -561,7 +561,7 @@ local M = {}
 -- match is a beginning fold point and `-1` indicates the match is an ending
 -- fold point. Likewise, the second assignment states that any "/\*" or "\*/"
 -- that the lexer recognizes as part of a `lexer.COMMENT` token is a fold point.
--- The lexer does not consider any occurences of these characters outside their
+-- The lexer does not consider any occurrences of these characters outside their
 -- defined tokens (such as in a string) as fold points. Finally, every
 -- `_foldsymbols` table must have a `_patterns` field that contains a list of
 -- [Lua patterns][] that match fold points. If the lexer encounters text that

--- a/lua/vis.lua
+++ b/lua/vis.lua
@@ -25,7 +25,7 @@
 -- 		file:insert(range.start, out)
 -- 	end
 -- 	return range.start -- new cursor location
--- end, "Formating operator, filter range through fmt(1)")
+-- end, "Formatting operator, filter range through fmt(1)")
 --
 vis.operator_new = function(vis, key, operator, help)
 	local id = vis:operator_register(operator)
@@ -47,7 +47,7 @@ end
 -- The motion function will receive the @{Window} and an initial position
 -- (in bytes from the start of the file) as argument and is expected to
 -- return the resulting position.
--- @tparam string key the key to associate with the new mption
+-- @tparam string key the key to associate with the new option
 -- @tparam function motion the motion logic implemented as Lua function
 -- @tparam[opt] string help the single line help text as displayed in `:help`
 -- @treturn bool whether the new motion could be installed
@@ -214,7 +214,7 @@ end
 -- value terminates the event propagation. The other handlers will not be called.
 --
 -- @tparam string event the event name
--- @tparam ... ... the remaining paramters are passed on to the handler
+-- @tparam ... ... the remaining parameters are passed on to the handler
 events.emit = function(event, ...)
 	local h = handlers[event]
 	if not h then return end

--- a/text-motions.h
+++ b/text-motions.h
@@ -2,7 +2,7 @@
 #define TEXT_MOTIONS_H
 
 /* these functions all take a position in bytes from the start of the file,
- * perform a certain movement and return the new postion. If the movement
+ * perform a certain movement and return the new position. If the movement
  * is not possible the original position is returned unchanged. */
 
 #include <stddef.h>

--- a/text-objects.h
+++ b/text-objects.h
@@ -16,10 +16,10 @@ Filerange text_object_word(Text*, size_t pos);
 /* includes trailing white spaces. If at pos happens to be a white space
  * include all neighbouring leading white spaces and the following word. */
 Filerange text_object_word_outer(Text*, size_t pos);
-/* find next occurence of `word' (as word not substring) in forward/backward direction */
+/* find next occurrence of `word' (as word not substring) in forward/backward direction */
 Filerange text_object_word_find_next(Text*, size_t pos, const char *word);
 Filerange text_object_word_find_prev(Text*, size_t pos, const char *word);
-/* find next occurence of a literal string (not regex) in forward/backward direction */
+/* find next occurrence of a literal string (not regex) in forward/backward direction */
 Filerange text_object_find_next(Text *txt, size_t pos, const char *search);
 Filerange text_object_find_prev(Text *txt, size_t pos, const char *search);
 /* same semantics as above but for a longword (i.e. delimited by white spaces) */

--- a/text.c
+++ b/text.c
@@ -57,7 +57,7 @@ typedef struct Change Change;
 struct Change {
 	Span old;               /* all pieces which are being modified/swapped out by the change */
 	Span new;               /* all pieces which are introduced/swapped in by the change */
-	size_t pos;             /* absolute position at which the change occured */
+	size_t pos;             /* absolute position at which the change occurred */
 	Change *next;           /* next change which is part of the same revision */
 	Change *prev;           /* previous change which is part of the same revision */
 };
@@ -120,7 +120,7 @@ static Revision *revision_alloc(Text *txt);
 static void revision_free(Revision *rev);
 /* logical line counting cache */
 static void lineno_cache_invalidate(LineCache *cache);
-static size_t lines_skip_forward(Text *txt, size_t pos, size_t lines, size_t *lines_skiped);
+static size_t lines_skip_forward(Text *txt, size_t pos, size_t lines, size_t *lines_skipped);
 static size_t lines_count(Text *txt, size_t pos, size_t len);
 
 /* stores the given data in a block, allocates a new one if necessary. Returns
@@ -335,7 +335,7 @@ static Location piece_get_intern(Text *txt, size_t pos) {
 	return (Location){ 0 };
 }
 
-/* similiar to piece_get_intern but usable as a public API. Returns the piece
+/* similar to piece_get_intern but usable as a public API. Returns the piece
  * holding the text at byte offset pos. Never returns a sentinel piece.
  * it pos is the end of file (== text_size()) and the file is not empty then
  * the last piece holding data is returned.
@@ -388,7 +388,7 @@ static void change_free(Change *c) {
 
 /* When inserting new data there are 2 cases to consider.
  *
- *  - in the first the insertion point falls into the middle of an exisiting
+ *  - in the first the insertion point falls into the middle of an existing
  *    piece which is replaced by three new pieces:
  *
  *      /-+ --> +---------------+ --> +-\
@@ -401,7 +401,7 @@ static void change_free(Change *c) {
  *      | |     | existing|     |demo |     |text |     | |
  *      \-+ <-- +---------+ <-- +-----+ <-- +-----+ <-- +-/
  *
- *  - the second case deals with an insertion point at a piece boundry:
+ *  - the second case deals with an insertion point at a piece boundary:
  *
  *      /-+ --> +---------------+ --> +-\
  *      | |     | existing text |     | |

--- a/text.h
+++ b/text.h
@@ -177,7 +177,7 @@ bool text_snapshot(Text*);
  */
 size_t text_undo(Text*);
 /**
- * Reapply an older change along the main brach.
+ * Reapply an older change along the main branch.
  * @rst
  * .. note:: Takes an implicit snapshot.
  * @endrst

--- a/view.c
+++ b/view.c
@@ -103,7 +103,7 @@ static Cell cell_unused;
 
 /* move visible viewport n-lines up/down, redraws the view but does not change
  * cursor position which becomes invalid and should be corrected by calling
- * view_cursor_to. the return value indicates wether the visible area changed.
+ * view_cursor_to. the return value indicates whether the visible area changed.
  */
 static bool view_viewport_up(View *view, int n);
 static bool view_viewport_down(View *view, int n);
@@ -316,7 +316,7 @@ bool view_coord_get(View *view, size_t pos, Line **retline, int *retrow, int *re
 	return true;
 }
 
-/* move the cursor to the character at pos bytes from the begining of the file.
+/* move the cursor to the character at pos bytes from the beginning of the file.
  * if pos is not in the current viewport, redraw the view to make it visible */
 void view_cursor_to(View *view, size_t pos) {
 	view_cursors_to(view->selection, pos);

--- a/view.h
+++ b/view.h
@@ -57,7 +57,7 @@ Filerange view_viewport_get(View*);
  * Get window coordinate of text position.
  * @param pos The position to query.
  * @param line Will be updated with screen line on which ``pos`` resides.
- * @param row Will be updaded with zero based window row on which ``pos`` resides.
+ * @param row Will be updated with zero based window row on which ``pos`` resides.
  * @param col Will be updated with zero based window column on which ``pos`` resides.
  * @return Whether ``pos`` is visible. If not, the pointer arguments are left unmodified.
  */

--- a/vis-core.h
+++ b/vis-core.h
@@ -83,7 +83,7 @@ typedef struct { /* Motion implementation, takes a cursor position and returns a
 		CHARWISE  = VIS_MOTIONTYPE_CHARWISE,  /* scrolls window content until position is visible */
 		INCLUSIVE = 1 << 2,  /* should new position be included in operator range? */
 		LINEWISE_INCLUSIVE = 1 << 3,  /* inclusive, but only if motion is linewise? */
-		IDEMPOTENT = 1 << 4, /* does the returned postion remain the same if called multiple times? */
+		IDEMPOTENT = 1 << 4, /* does the returned position remain the same if called multiple times? */
 		JUMP = 1 << 5, /* should the resulting position of the motion be recorded in the jump list? */
 		COUNT_EXACT = 1 << 6, /* fail (keep initial position) if count can not be satisfied exactly */
 	} type;
@@ -206,10 +206,10 @@ struct Vis {
 	int nesting_level;                   /* parsing state to hold keep track of { } nesting level */
 	volatile bool running;               /* exit main loop once this becomes false */
 	int exit_status;                     /* exit status when terminating main loop */
-	volatile sig_atomic_t interrupted;   /* abort command (SIGINT occured) */
+	volatile sig_atomic_t interrupted;   /* abort command (SIGINT occurred) */
 	volatile sig_atomic_t sigbus;        /* one of the memory mapped regions became unavailable (SIGBUS) */
-	volatile sig_atomic_t need_resize;   /* need to resize UI (SIGWINCH occured) */
-	volatile sig_atomic_t resume;        /* need to resume UI (SIGCONT occured) */
+	volatile sig_atomic_t need_resize;   /* need to resize UI (SIGWINCH occurred) */
+	volatile sig_atomic_t resume;        /* need to resume UI (SIGCONT occurred) */
 	volatile sig_atomic_t terminate;     /* need to terminate we were being killed by SIGTERM */
 	sigjmp_buf sigbus_jmpbuf;            /* used to jump back to a known good state in the mainloop after (SIGBUS) */
 	Map *actions;                        /* registered editor actions / special keys commands */

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -678,7 +678,7 @@ static int files_iter(lua_State *L) {
  * for name in vis:mark_names() do
  * 	local mark = marks[name]
  * 	for i = 1, #mark do
- * 		-- do somthing with: name, mark[i].start, mark[i].finish
+ * 		-- do something with: name, mark[i].start, mark[i].finish
  * 	end
  * end
  */
@@ -1154,9 +1154,9 @@ static bool option_lua(Vis *vis, Win *win, void *context, bool toggle,
  * @tparam[opt] string help the single line help text as displayed in `:help`
  * @treturn bool whether the option was successfully registered
  * @usage
- * vis:option_register("foo", "bool", function(value, toogle)
+ * vis:option_register("foo", "bool", function(value, toggle)
  * 	if not vis.win then return false end
- * 	vis.win.foo = toogle and not vis.win.foo or value
+ * 	vis.win.foo = toggle and not vis.win.foo or value
  * 	vis:info("Option foo = " .. tostring(vis.win.foo))
  * 	return true
  * end, "Foo enables superpowers")
@@ -1899,14 +1899,14 @@ static const struct luaL_Reg window_selections_funcs[] = {
  *    to the state before the deletion.
  *
  *  - Inserts after the selection position (`> selection.pos`) will not affect the
- *    selection postion.
+ *    selection position.
  *
  *        local pos = win.selection.pos
  *        win.file:insert(pos+1, "-")
  *        assert(win.selection.pos == pos)
  *
  *  - Non-cached inserts before the selection position (`<= selection.pos`) will
- *    affect the mark and adjust the selection postion by the number of bytes
+ *    affect the mark and adjust the selection position by the number of bytes
  *    which were inserted.
  *
  *        local pos = win.selection.pos
@@ -1922,7 +1922,7 @@ static const struct luaL_Reg window_selections_funcs[] = {
  *
  * 1. Read out the current selection position
  * 2. Perform text modifications
- * 3. Update the selection postion
+ * 3. Update the selection position
  *
  * This is what @{Vis:insert} and @{Vis:replace} do internally.
  *
@@ -2694,7 +2694,7 @@ static void *alloc_lua(void *ud, void *ptr, size_t osize, size_t nsize) {
 /***
  * Editor initialization completed.
  * This event is emitted immediately after `visrc.lua` has been sourced, but
- * before any other events have occured, in particular the command line arguments
+ * before any other events have occurred, in particular the command line arguments
  * have not yet been processed.
  *
  * Can be used to set *global* configuration options.
@@ -2755,7 +2755,7 @@ void vis_lua_init(Vis *vis) {
 	ssize_t len = readlink("/proc/self/exe", path, sizeof(path)-1);
 	if (len > 0) {
 		path[len] = '\0';
-		/* some idotic dirname(3) implementations return pointers to statically
+		/* some idiotic dirname(3) implementations return pointers to statically
 		 * allocated memory, hence we use memmove to copy it back */
 		char *dir = dirname(path);
 		if (dir) {
@@ -2995,7 +2995,7 @@ bool vis_lua_file_save_pre(Vis *vis, File *file, const char *path) {
 
 /***
  * File post save.
- * Triggered *after* a successfull write operation.
+ * Triggered *after* a successful write operation.
  * @function file_save_post
  * @tparam File file the file which was written
  * @tparam string path the absolute path to which it was written, `nil` if standard output

--- a/vis.c
+++ b/vis.c
@@ -1227,7 +1227,7 @@ static void vis_keys_process(Vis *vis, size_t pos) {
 		*end = tmp;
 
 		if (prefix) {
-			/* input sofar is ambigious, wait for more */
+			/* input so far is ambiguous, wait for more */
 			cur = end;
 			end = start;
 		} else if (binding) { /* exact match */

--- a/vis.h
+++ b/vis.h
@@ -145,7 +145,7 @@ void vis_suspend(Vis*);
  */
 void vis_resume(Vis*);
 /**
- * Inform the editor core that a signal occured.
+ * Inform the editor core that a signal occurred.
  * @return Whether the signal was handled.
  * @rst
  * .. note:: Being designed as a library the editor core does *not* register any
@@ -423,7 +423,7 @@ int vis_operator_register(Vis*, VisOperatorFunction*, void *context);
  *  - A visual mode is active.
  *  - The same operator was already set (range will be the current line).
  *
- * Otherwise the operator will be executed on the range determinded by:
+ * Otherwise the operator will be executed on the range determined by:
  *  - A motion (see `vis_motion`).
  *  - A text object (`vis_textobject`).
  *
@@ -595,7 +595,7 @@ VisCountIterator vis_count_iterator_init(Vis*, int count);
  * Increment iterator counter.
  * @return Whether iteration should continue.
  * @rst
- * .. note:: Terminates iteration if the edtior was
+ * .. note:: Terminates iteration if the editor was
  *           `interrupted <vis_interrupt>`_ in the meantime.
  * @endrst
  */


### PR DESCRIPTION
Ran most of the repo through aspell. It might be nit-picky but I believe this makes the documentation more readable and may help with grepping around.