### PR TITLE
Fix for #1028

### DIFF
--- a/text-motions.c
+++ b/text-motions.c
@@ -459,7 +459,8 @@ size_t text_paragraph_prev(Text *txt, size_t pos) {
 	char c;
 	Iterator it = text_iterator_get(txt, pos);
 
-	while (text_iterator_byte_prev(&it, &c) && (c == '\n' || blank(c)));
+	while (text_iterator_byte_get(&it, &c) && (c == '\n' || blank(c)))
+		text_iterator_char_prev(&it, NULL);
 	return text_line_blank_prev(txt, it.pos);
 }
 


### PR DESCRIPTION
Partial revert of [f55312b](https://github.com/martanne/vis/commit/f55312ba450c845e65f62b5592696d5f6ae98cda).

text_paragraph_prev():
Bring back the previous usage of text_iterator_byte_get() in the while conditional and text_iterator_char_prev() in the loop body.

Fixes #1028