### PR TITLE
don't set _FORTIFY_SOURCE in configure

### DIFF
--- a/configure
+++ b/configure
@@ -220,7 +220,7 @@ tryflag   CFLAGS_TRY  -Werror=unused-command-line-argument
 tryldflag LDFLAGS_TRY -Werror=unknown-warning-option
 tryldflag LDFLAGS_TRY -Werror=unused-command-line-argument
 
-CFLAGS_STD="-std=c99 -D_POSIX_C_SOURCE=200809L -U_XOPEN_SOURCE -D_XOPEN_SOURCE=700 -DNDEBUG -D_FORTIFY_SOURCE=2"
+CFLAGS_STD="-std=c99 -D_POSIX_C_SOURCE=200809L -U_XOPEN_SOURCE -D_XOPEN_SOURCE=700 -DNDEBUG"
 LDFLAGS_STD="-lc"
 
 OS=$(uname)


### PR DESCRIPTION
distributions that want this flag set do so on a system wide level. for
example Gentoo, Fedora, Debian, and OpenSUSE.

since vis sets it when invoking cc via make it overwrites the system
setting (and pollutes the output with redefinition warnings).

For reference here is the related bug in Gentoo:
https://bugs.gentoo.org/892960

Below is context for the discussion that follows:

Gentoo, Fedora, Debian and likely others add their own _FORTIFY_SOURCE declaration. At least for Gentoo this is in the compiler's default flags (now _FORTIFY_SOURCE=3) so the vis build command line overwrites it.

This commit allows packagers to skip the addition of _FORTIFY_SOURCE via the configure script so that their own define is properly applied. The default remains unchanged.

For reference here is the related bug in Gentoo:
https://bugs.gentoo.org/892960

Note: This patch is relatively dumb. It doesn't stop _FORTIFY_SOURCE from being added via any pkg-config commands. When I tried on my Arch system earlier TRE's pkg-config just added its own _FORTIFY_SOURCE=2. I think this might just be an issue on Arch's end though because I didn't have that problem with TRE on Gentoo.