### PR TITLE
vis.1: list equivalent key bindings on the same line

### DIFF
--- a/man/vis.1
+++ b/man/vis.1
@@ -1123,12 +1123,10 @@ clear (skip) current selection, but select next matching word
 .It Aq Ic C-p
 remove primary selection
 .
-.It Aq Ic C-u
-.It Aq Ic C-k
+.It Ao Ic C-u Ac Ao Ic C-k Ac
 make the count previous selection primary
 .
-.It Aq Ic C-d
-.It Aq Ic C-j
+.It Ao Ic C-d Ac Ao Ic C-j Ac
 make the count next selection primary
 .
 .It Aq Ic C-c


### PR DESCRIPTION
it is hard to tell which line `<C-u>` and `<C-d>` are supposed to belong to in the current version.

Note that if keeping the pairs on separate lines is preferred I can update the patch to say `same as xxx` instead.

see #1033