### PR TITLE
ci: remove deprecated ubuntu-18.04 and switch to ubuntu-latest

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,9 +7,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04 # should be latest, documentation is outdated
-          - ubuntu-20.04 # latest
-          - ubuntu-18.04
+          - ubuntu-latest
+          - ubuntu-20.04
         config:
           - ""
           - --disable-curses
@@ -37,11 +36,6 @@ jobs:
           libtermkey-dev \
           libtre-dev \
           lua-lpeg
-
-    - name: Dependency Ubuntu 18.04
-      if: matrix.os == 'ubuntu-18.04'
-      run: |
-        sudo apt install lua-busted
 
     - name: Build
       run: |


### PR DESCRIPTION
ubuntu-latest is supposed to track the newest supported ubuntu release which as of now is 22.04.

18.04 has been deprecated for a while and seems like it has finally been removed:

https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/