### PR TITLE
vis-clipboard: don't fail when sel is primary on unsupported platforms

### DIFF
--- a/man/vis-clipboard.1
+++ b/man/vis-clipboard.1
@@ -53,7 +53,8 @@ In this mode,
 reads the content of the system clipboard,
 and writes it to standard output.
 .It Fl -selection Ar selection
-specify which selection to use, options are "primary" or "clipboard"
+specify which selection to use, options are "primary" or
+"clipboard". Silently ignored on platforms with a single clipboard.
 .El
 .
 .Sh ENVIRONMENT

--- a/vis-clipboard
+++ b/vis-clipboard
@@ -37,10 +37,6 @@ vc_determine_command() {
 		done
 	fi
 
-	if [ "$sel" = "primary" ]; then
-		vc_fatal "clipboard primary selection is not supported on your platform"
-	fi
-
 	if command -v pbcopy >/dev/null 2>&1; then
 		echo 'mac'
 		return 0


### PR DESCRIPTION
this is mostly useful for the internal vis usage and makes both `*` and `+` ~buffers~ registers work on macOS/cygwin.

fixes: #1067

Note: I can't test this and I want others opinions on it. I don't even think the deleted check is correct right now since who is to say what the user meant when they specified `--selection` on macOS/cygwin.

Edit: I meant registers not buffers