### PR TITLE
Lua API: access and set all available options

### DIFF
--- a/man/vis.1
+++ b/man/vis.1
@@ -1393,16 +1393,16 @@ section.
 .It Cm syntax Op Cm auto
 Syntax highlighting lexer to use, name without file extension.
 .
-.It Cm show-tabs Op Cm off
+.It Cm showtabs Op Cm off
 Whether to display replacement symbol instead of tabs.
 .
-.It Cm show-newlines Op Cm off
+.It Cm shownewlines Op Cm off
 Whether to display replacement symbol instead of newlines.
 .
-.It Cm show-spaces Op Cm off
+.It Cm showspaces Op Cm off
 Whether to display replacement symbol instead of blank cells.
 .
-.It Cm show-eof Op Cm on
+.It Cm showeof Op Cm on
 Whether to display replacement symbol for lines after the end of the file.
 .
 .It Cm savemethod Op Ar auto

--- a/sam.c
+++ b/sam.c
@@ -332,22 +332,22 @@ static const OptionDef options[] = {
 		VIS_HELP("Number of spaces to display (and insert if `expandtab` is enabled) for a tab")
 	},
 	[OPTION_SHOW_SPACES] = {
-		{ "show-spaces" },
+		{ "showspaces" },
 		VIS_OPTION_TYPE_BOOL|VIS_OPTION_NEED_WINDOW,
 		VIS_HELP("Display replacement symbol instead of a space")
 	},
 	[OPTION_SHOW_TABS] = {
-		{ "show-tabs" },
+		{ "showtabs" },
 		VIS_OPTION_TYPE_BOOL|VIS_OPTION_NEED_WINDOW,
 		VIS_HELP("Display replacement symbol for tabs")
 	},
 	[OPTION_SHOW_NEWLINES] = {
-		{ "show-newlines" },
+		{ "shownewlines" },
 		VIS_OPTION_TYPE_BOOL|VIS_OPTION_NEED_WINDOW,
 		VIS_HELP("Display replacement symbol for newlines")
 	},
 	[OPTION_SHOW_EOF] = {
-		{ "show-eof" },
+		{ "showeof" },
 		VIS_OPTION_TYPE_BOOL|VIS_OPTION_NEED_WINDOW,
 		VIS_HELP("Display replacement symbol for lines after the end of the file")
 	},
@@ -382,7 +382,7 @@ static const OptionDef options[] = {
 		VIS_HELP("How to load existing files 'auto', 'read' or 'mmap'")
 	},
 	[OPTION_CHANGE_256COLORS] = {
-		{ "change-256colors" },
+		{ "change256colors" },
 		VIS_OPTION_TYPE_BOOL,
 		VIS_HELP("Change 256 color palette to support 24bit colors")
 	},

--- a/ui-terminal.c
+++ b/ui-terminal.c
@@ -678,6 +678,11 @@ err:
 	return false;
 }
 
+enum UiLayout ui_layout_get(Ui *ui) {
+	UiTerm *tui = (UiTerm *)ui;
+	return tui->layout;
+}
+
 Ui *ui_term_new(void) {
 	size_t styles_size = UI_STYLE_MAX * sizeof(CellStyle);
 	CellStyle *styles = calloc(1, styles_size);

--- a/ui.h
+++ b/ui.h
@@ -117,5 +117,6 @@ struct UiWin {
 };
 
 bool is_default_color(CellColor c);
+enum UiLayout ui_layout_get(Ui *ui);
 
 #endif

--- a/view.c
+++ b/view.c
@@ -910,6 +910,10 @@ void view_wrapcolumn_set(View *view, int col) {
 		view->wrapcolumn = col;
 }
 
+int view_wrapcolumn_get(View *view) {
+	return view->wrapcolumn;
+}
+
 bool view_breakat_set(View *view, const char *breakat) {
 	char *copy = strdup(breakat);
 	if (!copy)
@@ -917,6 +921,10 @@ bool view_breakat_set(View *view, const char *breakat) {
 	free(view->breakat);
 	view->breakat = copy;
 	return true;
+}
+
+const char *view_breakat_get(View *view) {
+	return view->breakat;
 }
 
 size_t view_screenline_goto(View *view, int n) {

--- a/view.h
+++ b/view.h
@@ -359,7 +359,9 @@ enum UiOption view_options_get(View*);
 void view_colorcolumn_set(View*, int col);
 int view_colorcolumn_get(View*);
 void view_wrapcolumn_set(View*, int col);
+int view_wrapcolumn_get(View*);
 bool view_breakat_set(View*, const char *breakat);
+const char *view_breakat_get(View*);
 
 /** Set how many spaces are used to display a tab `\t` character. */
 void view_tabwidth_set(View*, int tabwidth);

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -129,12 +129,22 @@ static void windows_arrange(Vis *vis, enum UiLayout layout) {
 	vis->ui->arrange(vis->ui, layout);
 }
 
-static void tabwidth_set(Vis *vis, int tabwidth) {
+void vis_tabwidth_set(Vis *vis, int tabwidth) {
 	if (tabwidth < 1 || tabwidth > 8)
 		return;
 	for (Win *win = vis->windows; win; win = win->next)
 		view_tabwidth_set(win->view, tabwidth);
 	vis->tabwidth = tabwidth;
+}
+
+void vis_shell_set(Vis *vis, const char *new_shell) {
+	char *shell =  strdup(new_shell);
+	if (!shell) {
+		vis_info_show(vis, "Failed to change shell");
+	} else {
+		free(vis->shell);
+		vis->shell = shell;
+	}
 }
 
 /* parse human-readable boolean value in s. If successful, store the result in
@@ -241,16 +251,8 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 
 	switch (opt_index) {
 	case OPTION_SHELL:
-	{
-		char *shell = strdup(arg.s);
-		if (!shell) {
-			vis_info_show(vis, "Failed to change shell");
-			return false;
-		}
-		free(vis->shell);
-		vis->shell = shell;
+		vis_shell_set(vis, arg.s);
 		break;
-	}
 	case OPTION_ESCDELAY:
 	{
 		TermKey *termkey = vis->ui->termkey_get(vis->ui);
@@ -264,7 +266,7 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 		vis->autoindent = toggle ? !vis->autoindent : arg.b;
 		break;
 	case OPTION_TABWIDTH:
-		tabwidth_set(vis, arg.i);
+		vis_tabwidth_set(vis, arg.i);
 		break;
 	case OPTION_SHOW_SPACES:
 	case OPTION_SHOW_TABS:

--- a/vis.h
+++ b/vis.h
@@ -584,6 +584,10 @@ int vis_count_get(Vis*);
 int vis_count_get_default(Vis*, int def);
 /** Set a count. */
 void vis_count_set(Vis*, int count);
+/** Set the tabwidth */
+void vis_tabwidth_set(Vis*, int tw);
+/** Set the shell */
+void vis_shell_set(Vis*, const char *new_shell);
 
 typedef struct {
 	Vis *vis;


### PR DESCRIPTION
the first point of this commit is to allow all options to be read from lua. this has a number of uses for plugin writers. they are grouped into a couple of tables depending on what they control: `vis.options`: table with global configuration
`win.options`: table with window specific configuration

the second point is to allow you to set all these options as if they were simply lua variables. technically this is already possible by using `vis:command("set ...")` but personally I think this interface is cleaner. Note that this already possible for some things like the current mode (eg. vis.mode = vis.modes.VISUAL). examples: `vis.options.ai = true`
`vis.options.brk = " !?."`

there are a number of related issues and pull requests:
closes #803: Lua API: let plugins read the values of options
closes #812: Window layout property
supersedes/closes #717: Add ability to access tabwidth from Lua
supersedes/closes #1066: expose UI layout and allow it to be set from lua API