### PR TITLE
Added lua-5.4 to list of libluas used to find installed lua version, or

### DIFF
--- a/configure
+++ b/configure
@@ -444,7 +444,7 @@ int main(int argc, char *argv[]) {
 }
 EOF
 
-	for liblua in lua lua5.4 lua5.3 lua5.2 lua-5.3 lua-5.2 lua54 lua53 lua52; do
+	for liblua in lua lua5.4 lua5.3 lua5.2 lua-5.4 lua-5.3 lua-5.2 lua54 lua53 lua52; do
 		printf " checking for %s... " "$liblua"
 
 		if test "$have_pkgconfig" = "yes" ; then


### PR DESCRIPTION
the latest if more than one installed. This change is specifically needed for FreeBSD.
modified:   configure