### PR TITLE
vis-lua: raise an error when mapping to invalid handler types

### DIFF
--- a/vis-lua.c
+++ b/vis-lua.c
@@ -832,6 +832,8 @@ static int keymap(lua_State *L, Vis *vis, Win *win) {
 			goto err;
 	} else if (lua_isuserdata(L, 4)) {
 		binding->action = obj_ref_check(L, 4, VIS_LUA_TYPE_KEYACTION);
+	} else {
+		goto err;
 	}
 
 	if (win) {


### PR DESCRIPTION
When passing an invalid handler type (such as nil) to Vis:map/Window:map, the editor would map the key to an empty (zeroed) KeyBinding that would cause itself to become unresponsive when processing the corresponding key.