### PR TITLE
text-io: fix block shrinking when the recent piece is on the block's end

### DIFF
--- a/text-io.c
+++ b/text-io.c
@@ -160,7 +160,7 @@ bool block_delete(Block *blk, size_t pos, size_t len) {
 	size_t end;
 	if (!addu(pos, len, &end) || end > blk->len)
 		return false;
-	if (blk->len == pos) {
+	if (blk->len == pos + len) {
 		blk->len -= len;
 		return true;
 	}


### PR DESCRIPTION
Looks like the original idea was to shrink the block if the text have been deleted on the recent piece which is located at the block's end, so in that case it is enough just to resize the block without memmove.