### PR TITLE
skip empty cells before applying a style

### DIFF
--- a/view.c
+++ b/view.c
@@ -1428,6 +1428,10 @@ void view_style(View *view, enum UiStyle style_id, size_t start, size_t end) {
 	while (pos < start && col < width)
 		pos += line->cells[col++].len;
 
+	/* skip empty columns */
+	while (!line->cells[col].len && col < width)
+		col++;
+
 	do {
 		while (pos <= end && col < width) {
 			pos += line->cells[col].len;


### PR DESCRIPTION
Fix empty cells erroneously being styled.

The view_style function is used to apply styles to ranges of text in a view.
It approaches the starting position where the style should be applied by
iterating the columns in the appropriate line using this while loop:

```C
while (pos < start && col < width)
	pos += line->cells[col++].len;
```

The while loop will stop at the last character before the range where the style
should be applied.

This works fine until we encounter "empty" cells between the last cell containing
an actual character and the first cell to be styled. This can happen if the last
character before the range to style is `'\t'` which gets expanded with empty cells
by vis according to the tabwidth option.
Those empty cells get erroneously styled as well.

This is fixed by skipping all empty cells encountered before the range to style.

Fixes: #1147.
