### PR TITLE
Added Github Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,36 @@
+name: Bug Report
+labels: bug
+description: Report a problem with vis.
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        ***Before reporting***, search [existing issues.](https://github.com/martanne/vis/issues?q=type%3Aissue)
+
+  - type: textarea
+    attributes:
+      label: "Problem"
+      description: "Describe the current behavior."
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Steps to reproduce"
+      placeholder: |
+        :,
+        :y/regex/
+  - type: input
+    attributes:
+      label: "vis version (vis -v)"
+      placeholder: "vis v0.7-151-g8ff0bea-dirty +curses +lua +tre +acl"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: "Terminal name/version"
+      placeholder: "st 0.8.2"
+  - type: input
+    attributes:
+      label: "$TERM environment variable"
+      placeholder: "st-256color"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: IRC Channel
+    url: https://web.libera.chat/#vis-editor
+    about: "Join the IRC channel #vis-editor on libera."
+  - name: Mailing List
+    url: https://lists.sr.ht/~martanne/devel
+    about: The vis Mailing List.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,13 @@
+name: Feature Request
+description: Thank you for your interest in improving vis.
+title: "[Feature Request]:"
+labels: [meta:feature-request]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### The current practise is for feature discussion to take place in the vis [mailing list](https://lists.sr.ht/~martanne/devel).
+
+  - type: textarea
+    attributes:
+      label: What feature would you like to see?


### PR DESCRIPTION
Following @mcepl [concerns on noise and bloat in the issue tracker,](https://github.com/martanne/vis/issues/1145#issuecomment-1756281015). I added a page to redirect feature request issues to the mailing list. 
In addition I also added a bug report page that prompts the user for useful information. I also thought it would be a good idea to add the mailing list and IRC to the landing page for more potential eyes on.

Currently you can see what these Issue templates look like [here](https://github.com/Sneethe/vis/issues/new/choose).

Please let me know if these are lacking in anyway. Maybe the [Bug Report page](https://github.com/Sneethe/vis/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml) could have some parts added/removed.
