### PR TITLE
Update deprecated change-256colors in vis-std.lua

### DIFF
--- a/lua/vis-std.lua
+++ b/lua/vis-std.lua
@@ -2,7 +2,7 @@
 
 vis.events.subscribe(vis.events.INIT, function()
 	if os.getenv("TERM_PROGRAM") == "Apple_Terminal" then
-		vis:command("set change-256colors false");
+		vis:command("set change256colors false");
 	end
 	vis:command("set theme ".. (vis.ui.colors <= 16 and "default-16" or "default-256"))
 end)


### PR DESCRIPTION
This caused a warning on startup when using Apple Terminal. I have no clue what this does and whether it is still necessary, but at least now it is silent.