### PR TITLE
use correct apostrophe in error message

### DIFF
--- a/main.c
+++ b/main.c
@@ -2332,7 +2332,7 @@ int main(int argc, char *argv[]) {
 			cmd = argv[i] + (argv[i][1] == '/' || argv[i][1] == '?');
 			continue;
 		} else if (!vis_window_new(vis, argv[i])) {
-			vis_die(vis, "Can not load `%s': %s\n", argv[i], strerror(errno));
+			vis_die(vis, "Can not load '%s': %s\n", argv[i], strerror(errno));
 		}
 		win_created = true;
 		if (cmd) {


### PR DESCRIPTION
Use correct apostrophe in error message. E.g. when trying to open a directory.

BTW: I noticed that the error messages varies a bit, e.g. we use both "Can not", "Can't", "Could not", "Failed to". Perhaps these could be expressed in one way? I suggest "Can not" (as it is the most used). BTW "Cannot" is also a normally used word to express this.