### PR TITLE
vis_pipe*: take a Text object, vis-lua: add pipe_buffer

### DIFF
--- a/lua/plugins/complete-word.lua
+++ b/lua/plugins/complete-word.lua
@@ -24,8 +24,7 @@ vis:map(vis.modes.INSERT, "<C-n>", function()
 	if #candidates == 1 and candidates[1] == "\n" then return end
 	candidates = table.concat(candidates, "\n")
 
-	local cmd = "printf '" .. candidates .. "' | sort -u | vis-menu"
-	local status, out, err = vis:pipe(cmd)
+	local status, out, err = vis:pipe_buffer(candidates, "sort -u | vis-menu")
 	if status ~= 0 or not out then
 		if err then vis:info(err) end
 		return

--- a/sam.c
+++ b/sam.c
@@ -1767,7 +1767,7 @@ static bool cmd_filter(Vis *vis, Win *win, Command *cmd, const char *argv[], Sel
 	buffer_init(&bufout);
 	buffer_init(&buferr);
 
-	int status = vis_pipe(vis, win->file, range, &argv[1], &bufout, read_buffer, &buferr, read_buffer, false);
+	int status = vis_pipe(vis, win->file->text, win->file->name, range, &argv[1], &bufout, read_buffer, &buferr, read_buffer, false);
 
 	if (vis->interrupted) {
 		vis_info_show(vis, "Command cancelled");
@@ -1807,7 +1807,7 @@ static bool cmd_pipeout(Vis *vis, Win *win, Command *cmd, const char *argv[], Se
 	Buffer buferr;
 	buffer_init(&buferr);
 
-	int status = vis_pipe(vis, win->file, range, (const char*[]){ argv[1], NULL }, NULL, NULL, &buferr, read_buffer, false);
+	int status = vis_pipe(vis, win->file->text, win->file->name, range, (const char*[]){ argv[1], NULL }, NULL, NULL, &buferr, read_buffer, false);
 
 	if (vis->interrupted)
 		vis_info_show(vis, "Command cancelled");

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -414,7 +414,7 @@ static const char *file_open_dialog(Vis *vis, const char *pattern) {
 		return NULL;
 
 	Filerange empty = text_range_new(0,0);
-	int status = vis_pipe(vis, vis->win->file, &empty,
+	int status = vis_pipe(vis, vis->win->file->text, vis->win->file->name, &empty,
 		(const char*[]){ buffer_content0(&bufcmd), NULL },
 		&bufout, read_buffer, &buferr, read_buffer, false);
 

--- a/vis-registers.c
+++ b/vis-registers.c
@@ -81,7 +81,7 @@ const char *register_slot_get(Vis *vis, Register *reg, size_t slot, size_t *len)
 			cmd[3] = "primary";
 		else
 			cmd[3] = "clipboard";
-		int status = vis_pipe(vis, vis->win->file,
+		int status = vis_pipe(vis, vis->win->file->text, vis->win->file->name,
 			&(Filerange){ .start = 0, .end = 0 },
 			cmd, buf, read_buffer, &buferr, read_buffer, false);
 
@@ -166,7 +166,7 @@ bool register_slot_put_range(Vis *vis, Register *reg, size_t slot, Text *txt, Fi
 		else
 			cmd[3] = "clipboard";
 
-		int status = vis_pipe(vis, vis->win->file, range,
+		int status = vis_pipe(vis, vis->win->file->text, vis->win->file->name, range,
 			cmd, NULL, NULL, &buferr, read_buffer, false);
 
 		if (status != 0)

--- a/vis.c
+++ b/vis.c
@@ -1708,14 +1708,13 @@ Regex *vis_regex(Vis *vis, const char *pattern) {
 	return regex;
 }
 
-int vis_pipe(Vis *vis, File *file, Filerange *range, const char *argv[],
+int vis_pipe(Vis *vis, Text *text, const char *file_name, Filerange *range, const char *argv[],
 	void *stdout_context, ssize_t (*read_stdout)(void *stdout_context, char *data, size_t len),
 	void *stderr_context, ssize_t (*read_stderr)(void *stderr_context, char *data, size_t len),
 	bool fullscreen) {
 
 	/* if an invalid range was given, stdin (i.e. key board input) is passed
 	 * through the external command. */
-	Text *text = file->text;
 	int pin[2], pout[2], perr[2], status = -1;
 	bool interactive = !text_range_valid(range);
 	Filerange rout = interactive ? text_range_new(0, 0) : *range;
@@ -1803,10 +1802,10 @@ int vis_pipe(Vis *vis, File *file, Filerange *range, const char *argv[],
 		close(perr[1]);
 		close(null);
 
-		if (file->name) {
-			char *name = strrchr(file->name, '/');
-			setenv("vis_filepath", file->name, 1);
-			setenv("vis_filename", name ? name+1 : file->name, 1);
+		if (file_name) {
+			char *name = strrchr(file_name, '/');
+			setenv("vis_filepath", file_name, 1);
+			setenv("vis_filename", name ? name+1 : file_name, 1);
 		}
 
 		if (!argv[1])
@@ -1943,11 +1942,11 @@ static ssize_t read_buffer(void *context, char *data, size_t len) {
 	return len;
 }
 
-int vis_pipe_collect(Vis *vis, File *file, Filerange *range, const char *argv[], char **out, char **err, bool fullscreen) {
+int vis_pipe_collect(Vis *vis, Text *text, const char *file_name, Filerange *range, const char *argv[], char **out, char **err, bool fullscreen) {
 	Buffer bufout, buferr;
 	buffer_init(&bufout);
 	buffer_init(&buferr);
-	int status = vis_pipe(vis, file, range, argv,
+	int status = vis_pipe(vis, text, file_name, range, argv,
 	                      &bufout, out ? read_buffer : NULL,
 	                      &buferr, err ? read_buffer : NULL,
 	                      fullscreen);

--- a/vis.h
+++ b/vis.h
@@ -920,7 +920,7 @@ bool vis_prompt_cmd(Vis*, const char *cmd);
  *
  * @return The exit status of the forked process.
  */
-int vis_pipe(Vis*, File*, Filerange*, const char *argv[],
+int vis_pipe(Vis*, Text*, const char *, Filerange*, const char *argv[],
 	void *stdout_context, ssize_t (*read_stdout)(void *stdout_context, char *data, size_t len),
 	void *stderr_context, ssize_t (*read_stderr)(void *stderr_context, char *data, size_t len),
 	bool fullscreen);
@@ -937,7 +937,7 @@ int vis_pipe(Vis*, File*, Filerange*, const char *argv[],
  *              by the caller.
  * @endrst
  */
-int vis_pipe_collect(Vis*, File*, Filerange*, const char *argv[], char **out, char **err, bool fullscreen);
+int vis_pipe_collect(Vis*, Text*, const char *, Filerange*, const char *argv[], char **out, char **err, bool fullscreen);
 
 /**
  * @}


### PR DESCRIPTION
This adds a pipe_buffer helper to the lua api to allow piping arbritary buffers to an external command, as the current way of constructing a `printf` command is quite hacky and is prone to shell injection

As a workaround, I'd written a wrapper like this but it messes up the scroll position, so made this PR instead:

```lua
vis.pipe_buffer = function(vis, buffer, cmd, fullscreen)
	vis:command("open")
	vis.win.file:insert(0, buffer)

	local status, stdout, stderr = vis:pipe(vis.win.file, {start = 0, finish = vis.win.file.size}, cmd, fullscreen)

	vis.win:close(true)

	return status, stdout, stderr
end
```