### PR TITLE
RFC: Direct access to cell styling via API

### DIFF
--- a/lua/vis.lua
+++ b/lua/vis.lua
@@ -167,6 +167,7 @@ local events = {
 	WIN_STATUS = "Event::WIN_STATUS", -- see @{win_status}
 	TERM_CSI = "Event::TERM_CSI", -- see @{term_csi}
 	PROCESS_RESPONSE = "Event::PROCESS_RESPONSE", -- see @{process_response}
+	UI_DRAW = "Event::UI_DRAW", -- see @{ui_draw}
 }
 
 events.file_close = function(...) events.emit(events.FILE_CLOSE, ...) end
@@ -183,6 +184,7 @@ events.win_open = function(...) events.emit(events.WIN_OPEN, ...) end
 events.win_status = function(...) events.emit(events.WIN_STATUS, ...) end
 events.term_csi = function(...) events.emit(events.TERM_CSI, ...) end
 events.process_response = function(...) events.emit(events.PROCESS_RESPONSE, ...) end
+events.ui_draw = function(...) events.emit(events.UI_DRAW, ...) end
 
 local handlers = {}
 

--- a/main.c
+++ b/main.c
@@ -2229,6 +2229,7 @@ int main(int argc, char *argv[]) {
 		.win_highlight = vis_lua_win_highlight,
 		.win_status = vis_lua_win_status,
 		.term_csi = vis_lua_term_csi,
+		.ui_draw = vis_lua_ui_draw,
 	};
 
 	vis = vis_new(ui_term_new(), &event);

--- a/ui-terminal.c
+++ b/ui-terminal.c
@@ -392,6 +392,7 @@ static void ui_draw(Ui *ui) {
 		ui_window_draw((UiWin*)win);
 	if (tui->info[0])
 		ui_draw_string(tui, 0, tui->height-1, tui->info, NULL, UI_STYLE_INFO);
+	vis_event_emit(tui->vis, VIS_EVENT_UI_DRAW);
 	ui_term_backend_blit(tui);
 }
 

--- a/ui-terminal.c
+++ b/ui-terminal.c
@@ -69,6 +69,9 @@ struct UiTermWin {
 #include "ui-terminal-vt100.c"
 #endif
 
+/* helper macro for handling UiTerm.cells */
+#define CELL_AT_POS(UI, X, Y) (((UI)->cells) + (X) + ((Y) * (UI)->width));
+
 __attribute__((noreturn)) static void ui_die(Ui *ui, const char *msg, va_list ap) {
 	UiTerm *tui = (UiTerm*)ui;
 	ui_term_backend_free(tui);
@@ -305,6 +308,17 @@ static void ui_window_style_set(UiWin *w, Cell *cell, enum UiStyle id) {
 	memcpy(&cell->style, &set, sizeof(CellStyle));
 }
 
+static bool ui_window_style_set_pos(UiWin *w, int x, int y, enum UiStyle id) {
+	UiTermWin *win = (UiTermWin*)w;
+	UiTerm *tui = win->ui;
+	if (x < 0 || y < 0 || y >= win->height || x >= win->width) {
+		return false;
+	}
+	Cell *cell = CELL_AT_POS(tui, win->x + x, win->y + y)
+	ui_window_style_set(w, cell, id);
+	return true;
+}
+
 static void ui_window_status(UiWin *w, const char *status) {
 	UiTermWin *win = (UiTermWin*)w;
 	if (!(win->options & UI_OPTION_STATUSBAR))
@@ -534,6 +548,7 @@ static UiWin *ui_window_new(Ui *ui, Win *w, enum UiOption options) {
 
 	win->uiwin = (UiWin) {
 		.style_set = ui_window_style_set,
+		.style_set_pos = ui_window_style_set_pos,
 		.status = ui_window_status,
 		.options_set = ui_window_options_set,
 		.options_get = ui_window_options_get,

--- a/ui.h
+++ b/ui.h
@@ -97,6 +97,7 @@ struct Ui {
 
 struct UiWin {
 	void (*style_set)(UiWin*, Cell*, enum UiStyle);
+	bool (*style_set_pos)(UiWin*, int x, int y, enum UiStyle);
 	void (*status)(UiWin*, const char *txt);
 	void (*options_set)(UiWin*, enum UiOption);
 	enum UiOption (*options_get)(UiWin*);

--- a/vis-core.h
+++ b/vis-core.h
@@ -236,6 +236,7 @@ enum VisEvents {
 	VIS_EVENT_WIN_HIGHLIGHT,
 	VIS_EVENT_WIN_STATUS,
 	VIS_EVENT_TERM_CSI,
+	VIS_EVENT_UI_DRAW,
 };
 
 bool vis_event_emit(Vis*, enum VisEvents, ...);

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -166,7 +166,7 @@ void vis_lua_win_status(Vis *vis, Win *win) { window_status_update(vis, win); }
 void vis_lua_term_csi(Vis *vis, const long *csi) { }
 void vis_lua_process_response(Vis *vis, const char *name,
                               char *buffer, size_t len, ResponseType rtype) { }
-
+void vis_lua_ui_draw(Vis *vis) { }
 
 #else
 
@@ -3687,6 +3687,18 @@ void vis_lua_process_response(Vis *vis, const char *name,
 		pcall(vis, L, 4, 0);
 	}
 	lua_pop(L, 1);
+}
+
+/***
+ * Emitted immediately before the UI is drawn to the screen.
+ * Allows last-minute overrides to the styling of UI elements.
+ *
+ * *WARNING:* This is emitted every screen draw!
+ * Use sparingly and check for `nil` values!
+ * @function ui_draw
+ */
+void vis_lua_ui_draw(Vis *vis) {
+	vis_lua_event_call(vis, "ui_draw");
 }
 
 #endif

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -1833,8 +1833,10 @@ static const struct luaL_Reg registers_funcs[] = {
  * Viewport currently being displayed.
  * Changing these values will not move the viewport.
  * @table viewport
- * @tfield Range bytes
- * @tfield Range lines
+ * @tfield Range bytes file bytes, from 0, at the start and end of the viewport
+ * @tfield Range lines file lines, from 1, at the top and bottom of the viewport
+ * @tfield int height lines in viewport, accounting for window decoration
+ * @tfield int width columns in viewport, accounting for window decoration
  */
 /***
  * The window width.
@@ -1875,12 +1877,18 @@ static int window_index(lua_State *L) {
 			l.start = view_lines_first(win->view)->lineno;
 			l.end = view_lines_last(win->view)->lineno;
 
-			lua_createtable(L, 0, 2);
+			lua_createtable(L, 0, 4);
 			lua_pushstring(L, "bytes");
 			pushrange(L, &b);
 			lua_settable(L, -3);
 			lua_pushstring(L, "lines");
 			pushrange(L, &l);
+			lua_settable(L, -3);
+			lua_pushstring(L, "width");
+			lua_pushunsigned(L, view_width_get(win->view));
+			lua_settable(L, -3);
+			lua_pushstring(L, "height");
+			lua_pushunsigned(L, view_height_get(win->view));
 			lua_settable(L, -3);
 			return 1;
 		}

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -2107,6 +2107,32 @@ static int window_style(lua_State *L) {
 }
 
 /***
+ * Style the single terminal cell at the given coordinates, relative to this window.
+ *
+ * Completely independent of the file buffer, and can be used to style UI elements,
+ * such as the status bar.
+ * The style will be cleared after every window redraw.
+ * @function style_pos
+ * @tparam int id display style registered with @{style_define}
+ * @tparam int x 0-based x coordinate within Win, where (0,0) is the top left corner
+ * @tparam int y See above
+ * @treturn bool false if the coordinates would be outside the window's dimensions
+ * @see style_define
+ * @usage
+ * win:style_pos(win.STYLE_COLOR_COLUMN, 0, win.height - 1)
+ * -- Styles the first character of the status bar (or the last line, if disabled)
+ */
+static int window_style_pos(lua_State *L) {
+	Win *win = obj_ref_check(L, 1, VIS_LUA_TYPE_WINDOW);
+	enum UiStyle style = luaL_checkunsigned(L, 2);
+	size_t x = checkpos(L, 3);
+	size_t y = checkpos(L, 4);
+	bool ret = win->ui->style_set_pos(win->ui, (int)x, (int)y, style);
+	lua_pushboolean(L, ret);
+	return 1;
+}
+
+/***
  * Set window status line.
  *
  * @function status
@@ -2175,6 +2201,7 @@ static const struct luaL_Reg window_funcs[] = {
 	{ "unmap", window_unmap },
 	{ "style_define", window_style_define },
 	{ "style", window_style },
+	{ "style_pos", window_style_pos },
 	{ "status", window_status },
 	{ "draw", window_draw },
 	{ "close", window_close },

--- a/vis-lua.h
+++ b/vis-lua.h
@@ -42,5 +42,6 @@ void vis_lua_win_highlight(Vis*, Win*);
 void vis_lua_win_status(Vis*, Win*);
 void vis_lua_term_csi(Vis*, const long *);
 void vis_lua_process_response(Vis *, const char *, char *, size_t, ResponseType);
+void vis_lua_ui_draw(Vis*);
 
 #endif

--- a/vis.c
+++ b/vis.c
@@ -105,6 +105,10 @@ bool vis_event_emit(Vis *vis, enum VisEvents id, ...) {
 		if (vis->event->term_csi)
 			vis->event->term_csi(vis, va_arg(ap, const long *));
 		break;
+	case VIS_EVENT_UI_DRAW:
+		if (vis->event->ui_draw)
+			vis->event->ui_draw(vis);
+		break;
 	}
 
 	va_end(ap);

--- a/vis.h
+++ b/vis.h
@@ -58,6 +58,7 @@ typedef struct {
 	void (*win_highlight)(Vis*, Win*);
 	void (*win_status)(Vis*, Win*);
 	void (*term_csi)(Vis*, const long *);
+	void (*ui_draw)(Vis*);
 } VisEvent;
 
 /** Union used to pass arguments to key action functions. */


### PR DESCRIPTION
This pull request essentially exposes the new style handling from PR #1154 to the Lua API, allowing plugins to make direct changes to cells using a new `Win` method, `Win.style_pos`.

It also adds a new style constant, `STYLE_LEXER_MAX`, which provides a reliable way of defining new user styles without needing to interact with the lexer.

Finally, a new event in `ui-terminal.c`, UI_DRAW, allows plugin developers the opportunity to override all previous styling. This allows for the creation of new UI elements entirely within the Lua API. This event is emitted at quite a low level (outside of vis.c and in ui_draw, right before the backend blit function), so I'd like opinions on whether it's even a good idea to have events outside of vis.c. In my opinion, it's a reasonably UI-specific event which has different ramifications based on the GUI toolkit being used, so aside from perhaps an extra argument to indicate more information to the user (i.e. "terminal/curses/ansi", "tk", "gnome", w/e). I don't foresee many changes to it.

By exposing a low-level styling function, many feature requests become implementable using the Lua API alone. For example, the following snippet can be placed into visrc.lua in order to implement status bar styling (#1128):
```lua
-- Example usage for style_pos: styling the status bar
local modes = {
	[vis.modes.NORMAL] = 'NORMAL',
	[vis.modes.OPERATOR_PENDING] = '???',
	[vis.modes.VISUAL] = 'VISUAL',
	[vis.modes.VISUAL_LINE] = 'VISUAL-LINE',
	[vis.modes.INSERT] = 'INSERT',
	[vis.modes.REPLACE] = 'REPLACE',
}

vis.events.subscribe(vis.events.WIN_STATUS, function(win)
	local left_parts = {}
	local right_parts = {}
	local file = win.file
	local selection = win.selection

	local mode = modes[vis.mode]
	if mode ~= '' and vis.win == win then
		table.insert(left_parts, mode)
	end
-- insert the rest of the code from vis-std.lua here...
	local left = ' ' .. table.concat(left_parts, " » ") .. ' '
	local right = ' ' .. table.concat(right_parts, " « ") .. ' '
	win:status(left, right);

	-- this must be done after calling win:status()
	-- mode change styling
	win.STYLE_RED = win.STYLE_LEXER_MAX - 1
	win.STYLE_GREEN = win.STYLE_LEXER_MAX - 2
	win.STYLE_YELLOW = win.STYLE_LEXER_MAX - 3
	win.STYLE_BLUE = win.STYLE_LEXER_MAX - 4
	win.STYLE_CYAN = win.STYLE_LEXER_MAX - 5
	win.STYLE_MAGENTA = win.STYLE_LEXER_MAX - 6
	win:style_define(win.STYLE_RED, "fore:red,reverse,bold")
	win:style_define(win.STYLE_GREEN, "fore:green,reverse,bold")
	win:style_define(win.STYLE_YELLOW, "fore:yellow,reverse,bold")
	win:style_define(win.STYLE_BLUE, "fore:blue,reverse,bold")
	win:style_define(win.STYLE_CYAN, "fore:cyan,reverse,bold")
	win:style_define(win.STYLE_MAGENTA, "fore:magenta,reverse,bold")

	local modestyle = {
		[vis.modes.NORMAL] = win.STYLE_BLUE,
		[vis.modes.OPERATOR_PENDING] = win.STYLE_YELLOW,
		[vis.modes.VISUAL] = win.STYLE_GREEN,
		[vis.modes.VISUAL_LINE] = win.STYLE_CYAN,
		[vis.modes.INSERT] = win.STYLE_RED,
		[vis.modes.REPLACE] = win.STYLE_MAGENTA,
	}

	local style = modestyle[vis.mode]
	if style and vis.win == win then
		for c=0,#modes[vis.mode]+1 do
			win:style_pos(style, c, win.height - 1)
		end
	end
end)
```

And UI_DRAW can be used, for example, to allow tighter integration with debugging tools by visually marking important lines:
```lua
-- UI_DRAW example usecase: highlighting important line numbers
-- using scraped info from cc or gdb or whatever
local importantfile = "vis.c"
local linesinview = {3, 23, 6, 15}

vis.events.subscribe(vis.events.UI_DRAW, function()
	local win = vis.win
	if not win then
		return
	end
	local file = win.file.name
	if not file or file ~= importantfile then
		return
	end
	if not win.STYLE_RED then
		return
	end

	-- highlight the line number and the rightmost column
	for line=1,#linesinview do
		if win.options.numbers then
			win:style_pos(win.STYLE_RED, 0, linesinview[line] - 1)
			win:style_pos(win.STYLE_RED, 1, linesinview[line] - 1)
		end
		win:style_pos(win.STYLE_RED, win.width - 1, linesinview[line] - 1)
	end
end)
```
And the end result:
![image](https://github.com/martanne/vis/assets/25546304/588604fd-26d2-4cc7-a205-e713a7c9ac06)