### PR TITLE
lua: complete-filename: use biggest possible prefix

### DIFF
--- a/lua/plugins/complete-filename.lua
+++ b/lua/plugins/complete-filename.lua
@@ -13,7 +13,7 @@ local complete_filename = function(expand)
 	if not prefix then return end
 
 	-- Strip leading delimiters for some programming languages
-	local _, j = prefix:find("[{[(<'\"]+")
+	local _, j = prefix:find(".*[{[(<'\"]+")
 	if not expand and j then prefix = prefix:sub(j + 1) end
 
 	if prefix:match("^%s*$") then


### PR DESCRIPTION
This allows for example to complete file names in markdown images.

E.g.:    `![](pic<C-x><C-f>`    will complete the file name starting with pic.

Previously it would have detected the `'['` as prefix and looked for files starting with `](pic`.

Maybe I can sneek this in before #1185. This is sitting on top of my tree for quite some time now and I have not encountered any regression using the biggest possible match with our regex.

Apparently, my email setup is currently broken hence the github pull request.