### PR TITLE
RFC: Largish Cleanup and Refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,20 +4,20 @@ REGEX_SRC ?= text-regex.c
 
 SRC = array.c \
 	buffer.c \
+	event-basic.c \
 	libutf.c \
 	main.c \
 	map.c \
 	sam.c \
-	text.c \
 	text-common.c \
 	text-io.c \
 	text-iterator.c \
 	text-motions.c \
 	text-objects.c \
 	text-util.c \
+	text.c \
 	ui-terminal.c \
 	view.c \
-	vis.c \
 	vis-lua.c \
 	vis-marks.c \
 	vis-modes.c \
@@ -25,8 +25,9 @@ SRC = array.c \
 	vis-operators.c \
 	vis-prompt.c \
 	vis-registers.c \
-	vis-text-objects.c \
 	vis-subprocess.c \
+	vis-text-objects.c \
+	vis.c \
 	$(REGEX_SRC)
 OBJ = $(SRC:%.c=obj/%.o)
 

--- a/event-basic.c
+++ b/event-basic.c
@@ -6,7 +6,7 @@
 bool vis_event_emit(Vis *vis, enum VisEvents id, ...) {
 	if (!vis->initialized) {
 		vis->initialized = true;
-		ui_init(vis->ui, vis);
+		ui_init(&vis->ui, vis);
 	}
 
 	va_list ap;

--- a/event-basic.c
+++ b/event-basic.c
@@ -6,7 +6,7 @@
 bool vis_event_emit(Vis *vis, enum VisEvents id, ...) {
 	if (!vis->initialized) {
 		vis->initialized = true;
-		vis->ui->init(vis->ui, vis);
+		ui_init(vis->ui, vis);
 	}
 
 	va_list ap;

--- a/event-basic.c
+++ b/event-basic.c
@@ -1,0 +1,23 @@
+#include <stdarg.h>
+
+#include "vis-core.h"
+
+#if !CONFIG_LUA
+bool vis_event_emit(Vis *vis, enum VisEvents id, ...) {
+	if (!vis->initialized) {
+		vis->initialized = true;
+		vis->ui->init(vis->ui, vis);
+	}
+
+	va_list ap;
+	va_start(ap, id);
+
+	if (id == VIS_EVENT_WIN_STATUS) {
+		Win *win = va_arg(ap, Win*);
+		window_status_update(vis, win);
+	}
+
+	va_end(ap);
+	return true;
+}
+#endif

--- a/main.c
+++ b/main.c
@@ -1348,7 +1348,7 @@ static const char *selections_align_indent(Vis *vis, const char *keys, const Arg
 
 static const char *selections_clear(Vis *vis, const char *keys, const Arg *arg) {
 	View *view = vis_view(vis);
-	if (view_selections_count(view) > 1)
+	if (view->selection_count > 1)
 		view_selections_dispose_all(view);
 	else
 		view_selection_clear(view_selections_primary_get(view));
@@ -1356,7 +1356,7 @@ static const char *selections_clear(Vis *vis, const char *keys, const Arg *arg) 
 }
 
 static Selection *selection_new(View *view, Filerange *r, bool isprimary) {
-	Text *txt = view_text(view);
+	Text *txt = view->text;
 	size_t pos = text_char_prev(txt, r->end);
 	Selection *s = view_selections_new(view, pos);
 	if (!s)
@@ -1378,7 +1378,7 @@ static const char *selections_match_next(Vis *vis, const char *keys, const Arg *
 
 	static bool match_word;
 
-	if (view_selections_count(view) == 1) {
+	if (view->selection_count == 1) {
 		Filerange word = text_object_word(txt, view_cursors_pos(s));
 		match_word = text_range_equal(&sel, &word);
 	}
@@ -1442,7 +1442,7 @@ static const char *selections_remove_column(Vis *vis, const char *keys, const Ar
 	int column = VIS_COUNT_DEFAULT(vis->action.count, arg->i) - 1;
 	if (column >= max)
 		column = max - 1;
-	if (view_selections_count(view) == 1) {
+	if (view->selection_count == 1) {
 		vis_keys_feed(vis, "<Escape>");
 		return keys;
 	}
@@ -1462,7 +1462,7 @@ static const char *selections_remove_column_except(Vis *vis, const char *keys, c
 	int column = VIS_COUNT_DEFAULT(vis->action.count, arg->i) - 1;
 	if (column >= max)
 		column = max - 1;
-	if (view_selections_count(view) == 1) {
+	if (view->selection_count == 1) {
 		vis_redraw(vis);
 		return keys;
 	}
@@ -1483,7 +1483,7 @@ static const char *selections_remove_column_except(Vis *vis, const char *keys, c
 
 static const char *selections_navigate(Vis *vis, const char *keys, const Arg *arg) {
 	View *view = vis_view(vis);
-	if (view_selections_count(view) == 1)
+	if (view->selection_count == 1)
 		return wscroll(vis, keys, arg);
 	Selection *s = view_selections_primary_get(view);
 	VisCountIterator it = vis_count_iterator_get(vis, 1);
@@ -1518,7 +1518,7 @@ static const char *selections_rotate(Vis *vis, const char *keys, const Arg *arg)
 	Text *txt = vis_text(vis);
 	View *view = vis_view(vis);
 	int columns = view_selections_column_count(view);
-	int selections = columns == 1 ? view_selections_count(view) : columns;
+	int selections = columns == 1 ? view->selection_count : columns;
 	int count = VIS_COUNT_DEFAULT(vis->action.count, 1);
 	array_init_sized(&arr, sizeof(Rotate));
 	if (!array_reserve(&arr, selections))
@@ -1877,7 +1877,7 @@ static const char *undo(Vis *vis, const char *keys, const Arg *arg) {
 	size_t pos = text_undo(vis_text(vis));
 	if (pos != EPOS) {
 		View *view = vis_view(vis);
-		if (view_selections_count(view) == 1)
+		if (view->selection_count == 1)
 			view_cursor_to(view, pos);
 		/* redraw all windows in case some display the same file */
 		vis_draw(vis);
@@ -1889,7 +1889,7 @@ static const char *redo(Vis *vis, const char *keys, const Arg *arg) {
 	size_t pos = text_redo(vis_text(vis));
 	if (pos != EPOS) {
 		View *view = vis_view(vis);
-		if (view_selections_count(view) == 1)
+		if (view->selection_count == 1)
 			view_cursor_to(view, pos);
 		/* redraw all windows in case some display the same file */
 		vis_draw(vis);

--- a/main.c
+++ b/main.c
@@ -2213,26 +2213,7 @@ static void signal_handler(int signum, siginfo_t *siginfo, void *context) {
 }
 
 int main(int argc, char *argv[]) {
-
-	VisEvent event = {
-		.init = vis_lua_init,
-		.start = vis_lua_start,
-		.quit = vis_lua_quit,
-		.mode_insert_input = vis_lua_mode_insert_input,
-		.mode_replace_input = vis_lua_mode_replace_input,
-		.file_open = vis_lua_file_open,
-		.file_save_pre = vis_lua_file_save_pre,
-		.file_save_post = vis_lua_file_save_post,
-		.file_close = vis_lua_file_close,
-		.win_open = vis_lua_win_open,
-		.win_close = vis_lua_win_close,
-		.win_highlight = vis_lua_win_highlight,
-		.win_status = vis_lua_win_status,
-		.term_csi = vis_lua_term_csi,
-		.ui_draw = vis_lua_ui_draw,
-	};
-
-	vis = vis_new(ui_term_new(), &event);
+	vis = vis_new(ui_term_new());
 	if (!vis)
 		return EXIT_FAILURE;
 

--- a/main.c
+++ b/main.c
@@ -1229,7 +1229,7 @@ static const char *macro_replay(Vis *vis, const char *keys, const Arg *arg) {
 }
 
 static const char *suspend(Vis *vis, const char *keys, const Arg *arg) {
-	ui_terminal_suspend(vis->ui);
+	ui_terminal_suspend(&vis->ui);
 	return keys;
 }
 
@@ -2214,7 +2214,7 @@ static void signal_handler(int signum, siginfo_t *siginfo, void *context) {
 }
 
 int main(int argc, char *argv[]) {
-	vis = vis_new(ui_terminal_new());
+	vis = vis_new();
 	if (!vis)
 		return EXIT_FAILURE;
 

--- a/main.c
+++ b/main.c
@@ -10,7 +10,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include "ui-terminal.h"
+#include "ui.h"
 #include "vis.h"
 #include "vis-lua.h"
 #include "text-util.h"
@@ -1229,7 +1229,7 @@ static const char *macro_replay(Vis *vis, const char *keys, const Arg *arg) {
 }
 
 static const char *suspend(Vis *vis, const char *keys, const Arg *arg) {
-	vis_suspend(vis);
+	ui_terminal_suspend(vis->ui);
 	return keys;
 }
 
@@ -2214,7 +2214,7 @@ static void signal_handler(int signum, siginfo_t *siginfo, void *context) {
 }
 
 int main(int argc, char *argv[]) {
-	vis = vis_new(ui_term_new());
+	vis = vis_new(ui_terminal_new());
 	if (!vis)
 		return EXIT_FAILURE;
 

--- a/sam.c
+++ b/sam.c
@@ -1270,7 +1270,7 @@ enum SamError sam_cmd(Vis *vis, const char *s) {
 				if (c->sel) {
 					if (visual) {
 						view_selections_set(c->sel, &r);
-						view_selections_anchor(c->sel, true);
+						c->sel->anchored = true;
 					} else {
 						if (memchr(c->data, '\n', c->len))
 							view_cursors_to(c->sel, r.start);
@@ -1281,7 +1281,7 @@ enum SamError sam_cmd(Vis *vis, const char *s) {
 					Selection *sel = view_selections_new(c->win->view, r.start);
 					if (sel) {
 						view_selections_set(sel, &r);
-						view_selections_anchor(sel, true);
+						sel->anchored = true;
 					}
 				}
 			}
@@ -1295,12 +1295,12 @@ enum SamError sam_cmd(Vis *vis, const char *s) {
 
 	if (vis->win) {
 		if (primary_pos != EPOS && view_selection_disposed(vis->win->view))
-			view_cursor_to(vis->win->view, primary_pos);
+			view_cursors_to(vis->win->view->selection, primary_pos);
 		view_selections_primary_set(view_selections(vis->win->view));
 		vis_jumplist_save(vis);
 		bool completed = true;
 		for (Selection *s = view_selections(vis->win->view); s; s = view_selections_next(s)) {
-			if (view_selections_anchored(s)) {
+			if (s->anchored) {
 				completed = false;
 				break;
 			}
@@ -1572,7 +1572,7 @@ static bool cmd_print(Vis *vis, Win *win, Command *cmd, const char *argv[], Sele
 		return false;
 	if (range->start != range->end) {
 		view_selections_set(sel, range);
-		view_selections_anchor(sel, true);
+		sel->anchored = true;
 	} else {
 		view_cursors_to(sel, range->start);
 		view_selection_clear(sel);

--- a/sam.c
+++ b/sam.c
@@ -1509,11 +1509,11 @@ static bool cmd_select(Vis *vis, Win *win, Command *cmd, const char *argv[], Sel
 	bool ret = true;
 	View *view = win->view;
 	Text *txt = win->file->text;
-	bool multiple_cursors = view_selections_count(view) > 1;
+	bool multiple_cursors = view->selection_count > 1;
 	Selection *primary = view_selections_primary_get(view);
 
 	if (vis->mode->visual)
-		count_init(cmd->cmd, view_selections_count(view)+1);
+		count_init(cmd->cmd, view->selection_count + 1);
 
 	for (Selection *s = view_selections(view), *next; s && ret; s = next) {
 		next = view_selections_next(s);

--- a/ui-terminal-curses.c
+++ b/ui-terminal-curses.c
@@ -276,8 +276,8 @@ static bool ui_term_backend_init(Ui *tui, char *term) {
 	return true;
 }
 
-static Ui *ui_term_backend_new(void) {
-	return calloc(1, sizeof(Ui));
+static bool ui_backend_init(Ui *ui) {
+	return true;
 }
 
 void ui_terminal_resume(Ui *term) { }

--- a/ui-terminal.c
+++ b/ui-terminal.c
@@ -58,7 +58,7 @@ static void ui_window_resize(UiWin *win, int width, int height) {
 	bool status = win->options & UI_OPTION_STATUSBAR;
 	win->width = width;
 	win->height = height;
-	view_resize(win->win->view, width - win->sidebar_width, status ? height - 1 : height);
+	view_resize(&win->win->view, width - win->sidebar_width, status ? height - 1 : height);
 }
 
 static void ui_window_move(UiWin *win, int x, int y) {
@@ -204,7 +204,7 @@ static void ui_draw_string(Ui *tui, int x, int y, const char *str, UiWin *win, e
 
 static void ui_window_draw(UiWin *win) {
 	Ui *ui = win->ui;
-	View *view = win->win->view;
+	View *view = &win->win->view;
 	int width = win->width, height = win->height;
 	const Line *line = view->topline;
 	bool status = win->options & UI_OPTION_STATUSBAR;
@@ -351,7 +351,7 @@ void ui_draw(Ui *tui) {
 void ui_redraw(Ui *tui) {
 	ui_term_backend_clear(tui);
 	for (UiWin *win = tui->windows; win; win = win->next)
-		win->win->view->need_update = true;
+		win->win->view.need_update = true;
 }
 
 void ui_resize(Ui *tui) {
@@ -405,8 +405,8 @@ void ui_window_focus(UiWin *new) {
 	if (new->options & UI_OPTION_STATUSBAR)
 		new->ui->selwin = new;
 	if (old)
-		old->win->view->need_update = true;
-	new->win->view->need_update = true;
+		old->win->view.need_update = true;
+	new->win->view.need_update = true;
 }
 
 void ui_window_options_set(UiWin *win, enum UiOption options) {
@@ -500,7 +500,7 @@ UiWin *ui_window_new(Ui *tui, Win *w, enum UiOption options) {
 	styles[UI_STYLE_STATUS].attr |= CELL_ATTR_REVERSE;
 	styles[UI_STYLE_STATUS_FOCUSED].attr |= CELL_ATTR_REVERSE|CELL_ATTR_BOLD;
 	styles[UI_STYLE_INFO].attr |= CELL_ATTR_BOLD;
-	w->view->ui = win;
+	w->view.ui = win;
 
 	if (tui->windows)
 		tui->windows->prev = win;

--- a/ui-terminal.c
+++ b/ui-terminal.c
@@ -257,8 +257,7 @@ static void ui_window_draw(UiWin *w) {
 	line = view->topline;
 	size_t prev_lineno = 0;
 	Selection *sel = view_selections_primary_get(view);
-	const Line *cursor_line = view_cursors_line_get(sel);
-	size_t cursor_lineno = cursor_line->lineno;
+	size_t cursor_lineno = sel->line->lineno;
 	char buf[(sizeof(size_t) * CHAR_BIT + 2) / 3 + 1 + 1];
 	int x = win->x, y = win->y;
 	int view_width = view->width;

--- a/ui-terminal.c
+++ b/ui-terminal.c
@@ -615,20 +615,19 @@ err:
 	return false;
 }
 
-Ui *ui_terminal_new(void) {
+bool ui_terminal_init(Ui *tui) {
 	size_t styles_size = UI_STYLE_MAX * sizeof(CellStyle);
 	CellStyle *styles = calloc(1, styles_size);
 	if (!styles)
-		return NULL;
-	Ui *tui = ui_term_backend_new();
-	if (!tui) {
+		return false;
+	if (!ui_backend_init(tui)) {
 		free(styles);
-		return NULL;
+		return false;
 	}
 	tui->styles_size = styles_size;
 	tui->styles = styles;
 	tui->doupdate = true;
-	return tui;
+	return true;
 }
 
 void ui_terminal_free(Ui *tui) {
@@ -641,5 +640,4 @@ void ui_terminal_free(Ui *tui) {
 		termkey_destroy(tui->termkey);
 	free(tui->cells);
 	free(tui->styles);
-	free(tui);
 }

--- a/ui-terminal.h
+++ b/ui-terminal.h
@@ -1,9 +1,0 @@
-#ifndef UI_TERMINAL_H
-#define UI_TERMINAL_H
-
-#include "ui.h"
-
-Ui *ui_term_new(void);
-void ui_term_free(Ui*);
-
-#endif

--- a/ui.h
+++ b/ui.h
@@ -107,6 +107,7 @@ typedef struct Ui {
 	size_t cells_size;        /* #bytes allocated for 2D grid (grows only) */
 	Cell *cells;              /* 2D grid of cells, at least as large as current terminal size */
 	bool doupdate;            /* Whether to update the screen after refreshing contents */
+	void *ctx;                /* Any additional data needed by the backend */
 } Ui;
 
 #include "view.h"
@@ -115,7 +116,7 @@ typedef struct Ui {
 
 #define UI_OPTIONS_GET(ui) ((ui) ? (ui)->options : 0)
 
-Ui *ui_terminal_new(void);
+bool ui_terminal_init(Ui*);
 int  ui_terminal_colors(void);
 void ui_terminal_free(Ui*);
 void ui_terminal_restore(Ui*);

--- a/ui.h
+++ b/ui.h
@@ -12,6 +12,7 @@
 
 typedef struct Ui Ui;
 typedef struct UiWin UiWin;
+typedef struct UiTerm UiTerm;
 
 enum UiLayout {
 	UI_LAYOUT_HORIZONTAL,
@@ -96,16 +97,24 @@ struct Ui {
 };
 
 struct UiWin {
-	void (*style_set)(UiWin*, Cell*, enum UiStyle);
-	bool (*style_set_pos)(UiWin*, int x, int y, enum UiStyle);
-	void (*status)(UiWin*, const char *txt);
-	void (*options_set)(UiWin*, enum UiOption);
-	enum UiOption (*options_get)(UiWin*);
-	bool (*style_define)(UiWin*, int id, const char *style);
-	int (*window_width)(UiWin*);
-	int (*window_height)(UiWin*);
+	UiTerm *ui;               /* ui which manages this window */
+	Win *win;                 /* editor window being displayed */
+	int id;                   /* unique identifier for this window */
+	int width, height;        /* window dimension including status bar */
+	int x, y;                 /* window position */
+	int sidebar_width;        /* width of the sidebar showing line numbers etc. */
+	UiWin *next, *prev;       /* pointers to neighbouring windows */
+	enum UiOption options;    /* display settings for this window */
 };
 
+#define UI_OPTIONS_GET(ui) ((ui) ? (ui)->options : 0)
+
+bool ui_style_define(UiWin *win, int id, const char *style);
+bool ui_window_style_set_pos(UiWin *win, int x, int y, enum UiStyle id);
+void ui_window_style_set(UiWin *win, Cell *cell, enum UiStyle id);
+
 enum UiLayout ui_layout_get(Ui *ui);
+void ui_window_options_set(UiWin *win, enum UiOption options);
+void ui_window_status(UiWin *win, const char *status);
 
 #endif

--- a/view.c
+++ b/view.c
@@ -134,7 +134,7 @@ void window_status_update(Vis *vis, Win *win) {
 	View *view = win->view;
 	File *file = win->file;
 	Text *txt = file->text;
-	int width = vis_window_width_get(win);
+	int width = win->ui->window_width(win->ui);
 	enum UiOption options = view_options_get(view);
 	bool focused = vis->win == win;
 	const char *filename = file_name_get(file);
@@ -148,7 +148,7 @@ void window_status_update(Vis *vis, Win *win) {
 	         text_modified(txt) ? " [+]" : "",
 	         vis_macro_recording(vis) ? " @": "");
 
-	int count = vis_count_get(vis);
+	int count = vis->action.count;
 	const char *keys = buffer_content0(&vis->input_queue);
 	if (keys && keys[0])
 		snprintf(right_parts[right_count++], sizeof(right_parts[0]), "%s", keys);

--- a/view.c
+++ b/view.c
@@ -74,8 +74,8 @@ void window_status_update(Vis *vis, Win *win) {
 	View *view = win->view;
 	File *file = win->file;
 	Text *txt = file->text;
-	int width = win->ui->window_width(win->ui);
-	enum UiOption options = view_options_get(view);
+	int width = win->ui->width;
+	enum UiOption options = UI_OPTIONS_GET(view->ui);
 	bool focused = vis->win == win;
 	const char *filename = file_name_get(file);
 	const char *mode = vis->mode->status;
@@ -153,7 +153,7 @@ void window_status_update(Vis *vis, Win *win) {
 		spaces = 1;
 
 	snprintf(status, sizeof(status), "%s%*s%s", left, spaces, " ", right);
-	vis_window_status(win, status);
+	ui_window_status(win->ui, status);
 }
 
 void view_tabwidth_set(View *view, int tabwidth) {
@@ -203,7 +203,7 @@ static void view_clear(View *view) {
 	view->wrapcol = 0;
 	view->prevch_breakat = false;
 	if (view->ui)
-		view->ui->style_set(view->ui, &view->cell_blank, UI_STYLE_DEFAULT);
+		ui_window_style_set(view->ui, &view->cell_blank, UI_STYLE_DEFAULT);
 }
 
 static int view_max_text_width(const View *view) {
@@ -890,11 +890,7 @@ void view_options_set(View *view, enum UiOption options) {
 	view->large_file = (options & UI_OPTION_LARGE_FILE);
 
 	if (view->ui)
-		view->ui->options_set(view->ui, options);
-}
-
-enum UiOption view_options_get(View *view) {
-	return view->ui ? view->ui->options_get(view->ui) : 0;
+		ui_window_options_set(view->ui, options);
 }
 
 bool view_breakat_set(View *view, const char *breakat) {
@@ -1351,10 +1347,6 @@ char *view_symbol_eof_get(View *view) {
 	return view->symbols[SYNTAX_SYMBOL_EOF]->symbol;
 }
 
-bool view_style_define(View *view, enum UiStyle id, const char *style) {
-	return view->ui->style_define(view->ui, id, style);
-}
-
 void view_style(View *view, enum UiStyle style, size_t start, size_t end) {
 	if (end < view->start || start > view->end)
 		return;
@@ -1384,7 +1376,7 @@ void view_style(View *view, enum UiStyle style, size_t start, size_t end) {
 	do {
 		while (pos <= end && col < width) {
 			pos += line->cells[col].len;
-			view->ui->style_set(view->ui, &line->cells[col++], style);
+			ui_window_style_set(view->ui, &line->cells[col++], style);
 		}
 		col = 0;
 	} while (pos <= end && (line = line->next));

--- a/view.h
+++ b/view.h
@@ -26,18 +26,6 @@ typedef struct {
 	Mark cursor;
 } SelectionRegion;
 
-typedef struct {
-	char data[16];      /* utf8 encoded character displayed in this cell (might be more than
-	                       one Unicode codepoint. might also not be the same as in the
-	                       underlying text, for example tabs get expanded */
-	size_t len;         /* number of bytes the character displayed in this cell uses, for
-	                       characters which use more than 1 column to display, their length
-	                       is stored in the leftmost cell whereas all following cells
-	                       occupied by the same character have a length of 0. */
-	int width;          /* display width i.e. number of columns occupied by this character */
-	CellStyle style;    /* colors and attributes used to display this cell */
-} Cell;
-
 typedef struct Line Line;
 struct Line {               /* a line on the screen, *not* in the file */
 	Line *prev, *next;  /* pointer to neighbouring screen lines */

--- a/view.h
+++ b/view.h
@@ -87,7 +87,7 @@ typedef struct View {
  * @defgroup view_life
  * @{
  */
-View *view_new(Text*);
+bool view_init(View*, Text*);
 void view_free(View*);
 void view_reload(View*, Text*);
 /**
@@ -96,7 +96,7 @@ void view_reload(View*, Text*);
  * @{
  */
 /** Get the currently displayed text range. */
-#define VIEW_VIEWPORT_GET(v) (Filerange){ .start = v->start, .end = v->end }
+#define VIEW_VIEWPORT_GET(v) (Filerange){ .start = v.start, .end = v.end }
 /**
  * Get window coordinate of text position.
  * @param pos The position to query.

--- a/view.h
+++ b/view.h
@@ -357,13 +357,10 @@ bool view_regions_save(View*, Filerange*, SelectionRegion*);
  * @{
  */
 void view_options_set(View*, enum UiOption options);
-enum UiOption view_options_get(View*);
 bool view_breakat_set(View*, const char *breakat);
 
 /** Set how many spaces are used to display a tab `\t` character. */
 void view_tabwidth_set(View*, int tabwidth);
-/** Define a display style. */
-bool view_style_define(View*, enum UiStyle, const char *style);
 /** Apply a style to a text range. */
 void view_style(View*, enum UiStyle, size_t start, size_t end);
 

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -276,7 +276,7 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 			[OPTION_SHOW_EOF] = UI_OPTION_SYMBOL_EOF,
 			[OPTION_STATUSBAR] = UI_OPTION_STATUSBAR,
 		};
-		int flags = view_options_get(win->view);
+		int flags = UI_OPTIONS_GET(win->view->ui);
 		if (arg.b || (toggle && !(flags & values[opt_index])))
 			flags |= values[opt_index];
 		else
@@ -285,7 +285,7 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 		break;
 	}
 	case OPTION_NUMBER: {
-		enum UiOption opt = view_options_get(win->view);
+		enum UiOption opt = UI_OPTIONS_GET(win->view->ui);
 		if (arg.b || (toggle && !(opt & UI_OPTION_LINE_NUMBERS_ABSOLUTE))) {
 			opt &= ~UI_OPTION_LINE_NUMBERS_RELATIVE;
 			opt |=  UI_OPTION_LINE_NUMBERS_ABSOLUTE;
@@ -296,7 +296,7 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 		break;
 	}
 	case OPTION_NUMBER_RELATIVE: {
-		enum UiOption opt = view_options_get(win->view);
+		enum UiOption opt = UI_OPTIONS_GET(win->view->ui);
 		if (arg.b || (toggle && !(opt & UI_OPTION_LINE_NUMBERS_RELATIVE))) {
 			opt &= ~UI_OPTION_LINE_NUMBERS_ABSOLUTE;
 			opt |=  UI_OPTION_LINE_NUMBERS_RELATIVE;
@@ -307,7 +307,7 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 		break;
 	}
 	case OPTION_CURSOR_LINE: {
-		enum UiOption opt = view_options_get(win->view);
+		enum UiOption opt = UI_OPTIONS_GET(win->view->ui);
 		if (arg.b || (toggle && !(opt & UI_OPTION_CURSOR_LINE)))
 			opt |= UI_OPTION_CURSOR_LINE;
 		else
@@ -545,7 +545,7 @@ static bool cmd_qall(Vis *vis, Win *win, Command *cmd, const char *argv[], Selec
 static bool cmd_split(Vis *vis, Win *win, Command *cmd, const char *argv[], Selection *sel, Filerange *range) {
 	if (!win)
 		return false;
-	enum UiOption options = view_options_get(win->view);
+	enum UiOption options = UI_OPTIONS_GET(win->view->ui);
 	windows_arrange(vis, UI_LAYOUT_HORIZONTAL);
 	if (!argv[1])
 		return vis_window_split(win);
@@ -558,7 +558,7 @@ static bool cmd_split(Vis *vis, Win *win, Command *cmd, const char *argv[], Sele
 static bool cmd_vsplit(Vis *vis, Win *win, Command *cmd, const char *argv[], Selection *sel, Filerange *range) {
 	if (!win)
 		return false;
-	enum UiOption options = view_options_get(win->view);
+	enum UiOption options = UI_OPTIONS_GET(win->view->ui);
 	windows_arrange(vis, UI_LAYOUT_VERTICAL);
 	if (!argv[1])
 		return vis_window_split(win);

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -316,7 +316,8 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 		break;
 	}
 	case OPTION_COLOR_COLUMN:
-		view_colorcolumn_set(win->view, arg.i);
+		if (arg.i >= 0)
+			win->view->colorcolumn = arg.i;
 		break;
 	case OPTION_SAVE_METHOD:
 		if (strcmp("auto", arg.s) == 0) {
@@ -370,7 +371,8 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 		}
 		break;
 	case OPTION_WRAP_COLUMN:
-		view_wrapcolumn_set(win->view, arg.i);
+		if (arg.i >= 0)
+			win->view->wrapcolumn = arg.i;
 		break;
 	default:
 		if (!opt->func)

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -876,7 +876,7 @@ static bool cmd_help(Vis *vis, Win *win, Command *cmd, const char *argv[], Selec
 		text_appendf(txt, "  %-32s\t%s\n", configs[i].name, configs[i].enabled ? "yes" : "no");
 
 	text_save(txt, NULL);
-	view_cursor_to(vis->win->view, 0);
+	view_cursors_to(vis->win->view->selection, 0);
 
 	if (argv[1])
 		vis_motion(vis, VIS_MOVE_SEARCH_FORWARD, argv[1]);

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -246,8 +246,7 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 		break;
 	case OPTION_ESCDELAY:
 	{
-		TermKey *termkey = vis->ui->termkey;
-		termkey_set_waittime(termkey, arg.i);
+		termkey_set_waittime(vis->ui.termkey, arg.i);
 		break;
 	}
 	case OPTION_EXPANDTAB:
@@ -354,7 +353,7 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 			vis_info_show(vis, "Invalid layout `%s', expected 'h' or 'v'", arg.s);
 			return false;
 		}
-		ui_arrange(vis->ui, layout);
+		ui_arrange(&vis->ui, layout);
 		break;
 	}
 	case OPTION_IGNORECASE:
@@ -542,7 +541,7 @@ static bool cmd_split(Vis *vis, Win *win, Command *cmd, const char *argv[], Sele
 	if (!win)
 		return false;
 	enum UiOption options = UI_OPTIONS_GET(win->view->ui);
-	ui_arrange(vis->ui, UI_LAYOUT_HORIZONTAL);
+	ui_arrange(&vis->ui, UI_LAYOUT_HORIZONTAL);
 	if (!argv[1])
 		return vis_window_split(win);
 	bool ret = openfiles(vis, &argv[1]);
@@ -555,7 +554,7 @@ static bool cmd_vsplit(Vis *vis, Win *win, Command *cmd, const char *argv[], Sel
 	if (!win)
 		return false;
 	enum UiOption options = UI_OPTIONS_GET(win->view->ui);
-	ui_arrange(vis->ui, UI_LAYOUT_VERTICAL);
+	ui_arrange(&vis->ui, UI_LAYOUT_VERTICAL);
 	if (!argv[1])
 		return vis_window_split(win);
 	bool ret = openfiles(vis, &argv[1]);
@@ -565,12 +564,12 @@ static bool cmd_vsplit(Vis *vis, Win *win, Command *cmd, const char *argv[], Sel
 }
 
 static bool cmd_new(Vis *vis, Win *win, Command *cmd, const char *argv[], Selection *sel, Filerange *range) {
-	ui_arrange(vis->ui, UI_LAYOUT_HORIZONTAL);
+	ui_arrange(&vis->ui, UI_LAYOUT_HORIZONTAL);
 	return vis_window_new(vis, NULL);
 }
 
 static bool cmd_vnew(Vis *vis, Win *win, Command *cmd, const char *argv[], Selection *sel, Filerange *range) {
-	ui_arrange(vis->ui, UI_LAYOUT_VERTICAL);
+	ui_arrange(&vis->ui, UI_LAYOUT_VERTICAL);
 	return vis_window_new(vis, NULL);
 }
 
@@ -775,7 +774,7 @@ static void print_symbolic_keys(Vis *vis, Text *txt) {
 		TERMKEY_SYM_KPEQUALS,
 	};
 
-	TermKey *termkey = vis->ui->termkey;
+	TermKey *termkey = vis->ui.termkey;
 	text_appendf(txt, "  ␣ (a literal \" \" space symbol must be used to refer to <Space>)\n");
 	for (size_t i = 0; i < LENGTH(keys); i++) {
 		text_appendf(txt, "  <%s>\n", termkey_get_keyname(termkey, keys[i]));

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -256,7 +256,7 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 		vis->autoindent = toggle ? !vis->autoindent : arg.b;
 		break;
 	case OPTION_TABWIDTH:
-		view_tabwidth_set(vis->win->view, arg.i);
+		view_tabwidth_set(&vis->win->view, arg.i);
 		break;
 	case OPTION_SHOW_SPACES:
 	case OPTION_SHOW_TABS:
@@ -271,48 +271,48 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 			[OPTION_SHOW_EOF] = UI_OPTION_SYMBOL_EOF,
 			[OPTION_STATUSBAR] = UI_OPTION_STATUSBAR,
 		};
-		int flags = UI_OPTIONS_GET(win->view->ui);
+		int flags = UI_OPTIONS_GET(win->view.ui);
 		if (arg.b || (toggle && !(flags & values[opt_index])))
 			flags |= values[opt_index];
 		else
 			flags &= ~values[opt_index];
-		view_options_set(win->view, flags);
+		view_options_set(&win->view, flags);
 		break;
 	}
 	case OPTION_NUMBER: {
-		enum UiOption opt = UI_OPTIONS_GET(win->view->ui);
+		enum UiOption opt = UI_OPTIONS_GET(win->view.ui);
 		if (arg.b || (toggle && !(opt & UI_OPTION_LINE_NUMBERS_ABSOLUTE))) {
 			opt &= ~UI_OPTION_LINE_NUMBERS_RELATIVE;
 			opt |=  UI_OPTION_LINE_NUMBERS_ABSOLUTE;
 		} else {
 			opt &= ~UI_OPTION_LINE_NUMBERS_ABSOLUTE;
 		}
-		view_options_set(win->view, opt);
+		view_options_set(&win->view, opt);
 		break;
 	}
 	case OPTION_NUMBER_RELATIVE: {
-		enum UiOption opt = UI_OPTIONS_GET(win->view->ui);
+		enum UiOption opt = UI_OPTIONS_GET(win->view.ui);
 		if (arg.b || (toggle && !(opt & UI_OPTION_LINE_NUMBERS_RELATIVE))) {
 			opt &= ~UI_OPTION_LINE_NUMBERS_ABSOLUTE;
 			opt |=  UI_OPTION_LINE_NUMBERS_RELATIVE;
 		} else {
 			opt &= ~UI_OPTION_LINE_NUMBERS_RELATIVE;
 		}
-		view_options_set(win->view, opt);
+		view_options_set(&win->view, opt);
 		break;
 	}
 	case OPTION_CURSOR_LINE: {
-		enum UiOption opt = UI_OPTIONS_GET(win->view->ui);
+		enum UiOption opt = UI_OPTIONS_GET(win->view.ui);
 		if (arg.b || (toggle && !(opt & UI_OPTION_CURSOR_LINE)))
 			opt |= UI_OPTION_CURSOR_LINE;
 		else
 			opt &= ~UI_OPTION_CURSOR_LINE;
-		view_options_set(win->view, opt);
+		view_options_set(&win->view, opt);
 		break;
 	}
 	case OPTION_COLOR_COLUMN:
 		if (arg.i >= 0)
-			win->view->colorcolumn = arg.i;
+			win->view.colorcolumn = arg.i;
 		break;
 	case OPTION_SAVE_METHOD:
 		if (strcmp("auto", arg.s) == 0) {
@@ -360,14 +360,14 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 		vis->ignorecase = toggle ? !vis->ignorecase : arg.b;
 		break;
 	case OPTION_BREAKAT:
-		if (!view_breakat_set(win->view, arg.s)) {
+		if (!view_breakat_set(&win->view, arg.s)) {
 			vis_info_show(vis, "Failed to set breakat");
 			return false;
 		}
 		break;
 	case OPTION_WRAP_COLUMN:
 		if (arg.i >= 0)
-			win->view->wrapcolumn = arg.i;
+			win->view.wrapcolumn = arg.i;
 		break;
 	default:
 		if (!opt->func)
@@ -540,26 +540,26 @@ static bool cmd_qall(Vis *vis, Win *win, Command *cmd, const char *argv[], Selec
 static bool cmd_split(Vis *vis, Win *win, Command *cmd, const char *argv[], Selection *sel, Filerange *range) {
 	if (!win)
 		return false;
-	enum UiOption options = UI_OPTIONS_GET(win->view->ui);
+	enum UiOption options = UI_OPTIONS_GET(win->view.ui);
 	ui_arrange(&vis->ui, UI_LAYOUT_HORIZONTAL);
 	if (!argv[1])
 		return vis_window_split(win);
 	bool ret = openfiles(vis, &argv[1]);
 	if (ret)
-		view_options_set(vis->win->view, options);
+		view_options_set(&vis->win->view, options);
 	return ret;
 }
 
 static bool cmd_vsplit(Vis *vis, Win *win, Command *cmd, const char *argv[], Selection *sel, Filerange *range) {
 	if (!win)
 		return false;
-	enum UiOption options = UI_OPTIONS_GET(win->view->ui);
+	enum UiOption options = UI_OPTIONS_GET(win->view.ui);
 	ui_arrange(&vis->ui, UI_LAYOUT_VERTICAL);
 	if (!argv[1])
 		return vis_window_split(win);
 	bool ret = openfiles(vis, &argv[1]);
 	if (ret)
-		view_options_set(vis->win->view, options);
+		view_options_set(&vis->win->view, options);
 	return ret;
 }
 
@@ -871,7 +871,7 @@ static bool cmd_help(Vis *vis, Win *win, Command *cmd, const char *argv[], Selec
 		text_appendf(txt, "  %-32s\t%s\n", configs[i].name, configs[i].enabled ? "yes" : "no");
 
 	text_save(txt, NULL);
-	view_cursors_to(vis->win->view->selection, 0);
+	view_cursors_to(vis->win->view.selection, 0);
 
 	if (argv[1])
 		vis_motion(vis, VIS_MOVE_SEARCH_FORWARD, argv[1]);

--- a/vis-cmds.c
+++ b/vis-cmds.c
@@ -125,10 +125,6 @@ static bool cmd_user(Vis *vis, Win *win, Command *cmd, const char *argv[], Selec
 	return user && user->func(vis, win, user->data, cmd->flags == '!', argv, sel, range);
 }
 
-static void windows_arrange(Vis *vis, enum UiLayout layout) {
-	vis->ui->arrange(vis->ui, layout);
-}
-
 void vis_shell_set(Vis *vis, const char *new_shell) {
 	char *shell =  strdup(new_shell);
 	if (!shell) {
@@ -250,7 +246,7 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 		break;
 	case OPTION_ESCDELAY:
 	{
-		TermKey *termkey = vis->ui->termkey_get(vis->ui);
+		TermKey *termkey = vis->ui->termkey;
 		termkey_set_waittime(termkey, arg.i);
 		break;
 	}
@@ -358,7 +354,7 @@ static bool cmd_set(Vis *vis, Win *win, Command *cmd, const char *argv[], Select
 			vis_info_show(vis, "Invalid layout `%s', expected 'h' or 'v'", arg.s);
 			return false;
 		}
-		windows_arrange(vis, layout);
+		ui_arrange(vis->ui, layout);
 		break;
 	}
 	case OPTION_IGNORECASE:
@@ -546,7 +542,7 @@ static bool cmd_split(Vis *vis, Win *win, Command *cmd, const char *argv[], Sele
 	if (!win)
 		return false;
 	enum UiOption options = UI_OPTIONS_GET(win->view->ui);
-	windows_arrange(vis, UI_LAYOUT_HORIZONTAL);
+	ui_arrange(vis->ui, UI_LAYOUT_HORIZONTAL);
 	if (!argv[1])
 		return vis_window_split(win);
 	bool ret = openfiles(vis, &argv[1]);
@@ -559,7 +555,7 @@ static bool cmd_vsplit(Vis *vis, Win *win, Command *cmd, const char *argv[], Sel
 	if (!win)
 		return false;
 	enum UiOption options = UI_OPTIONS_GET(win->view->ui);
-	windows_arrange(vis, UI_LAYOUT_VERTICAL);
+	ui_arrange(vis->ui, UI_LAYOUT_VERTICAL);
 	if (!argv[1])
 		return vis_window_split(win);
 	bool ret = openfiles(vis, &argv[1]);
@@ -569,12 +565,12 @@ static bool cmd_vsplit(Vis *vis, Win *win, Command *cmd, const char *argv[], Sel
 }
 
 static bool cmd_new(Vis *vis, Win *win, Command *cmd, const char *argv[], Selection *sel, Filerange *range) {
-	windows_arrange(vis, UI_LAYOUT_HORIZONTAL);
+	ui_arrange(vis->ui, UI_LAYOUT_HORIZONTAL);
 	return vis_window_new(vis, NULL);
 }
 
 static bool cmd_vnew(Vis *vis, Win *win, Command *cmd, const char *argv[], Selection *sel, Filerange *range) {
-	windows_arrange(vis, UI_LAYOUT_VERTICAL);
+	ui_arrange(vis->ui, UI_LAYOUT_VERTICAL);
 	return vis_window_new(vis, NULL);
 }
 
@@ -779,7 +775,7 @@ static void print_symbolic_keys(Vis *vis, Text *txt) {
 		TERMKEY_SYM_KPEQUALS,
 	};
 
-	TermKey *termkey = vis->ui->termkey_get(vis->ui);
+	TermKey *termkey = vis->ui->termkey;
 	text_appendf(txt, "  ␣ (a literal \" \" space symbol must be used to refer to <Space>)\n");
 	for (size_t i = 0; i < LENGTH(keys); i++) {
 		text_appendf(txt, "  <%s>\n", termkey_get_keyname(termkey, keys[i]));

--- a/vis-core.h
+++ b/vis-core.h
@@ -168,7 +168,6 @@ struct Win {
 };
 
 struct Vis {
-	Ui *ui;                              /* user interface responsible for visual appearance */
 	File *files;                         /* all files currently managed by this editor instance */
 	File *command_file;                  /* special internal file used to store :-command prompt */
 	File *search_file;                   /* special internal file used to store /,? search prompt */
@@ -176,6 +175,7 @@ struct Vis {
 	Win *windows;                        /* all windows currently managed by this editor instance */
 	Win *win;                            /* currently active/focused window */
 	Win *message_window;                 /* special window to display multi line messages */
+	Ui ui;                               /* user interface responsible for visual appearance */
 	Register registers[VIS_REG_INVALID]; /* registers used for text manipulations yank/put etc. and macros */
 	Macro *recording, *last_recording;   /* currently (if non NULL) and least recently recorded macro */
 	const Macro *replaying;              /* macro currently being replayed */

--- a/vis-core.h
+++ b/vis-core.h
@@ -157,7 +157,7 @@ struct Win {
 	Vis *vis;               /* editor instance to which this window belongs */
 	UiWin *ui;              /* ui object handling visual appearance of this window */
 	File *file;             /* file being displayed in this window */
-	View *view;             /* currently displayed part of underlying text */
+	View view;              /* currently displayed part of underlying text */
 	bool expandtab;         /* whether typed tabs should be converted to spaces in this window*/
 	MarkList jumplist;      /* LRU jump management */
 	Array saved_selections; /* register used to store selections */

--- a/vis-core.h
+++ b/vis-core.h
@@ -215,7 +215,6 @@ struct Vis {
 	Array actions_user;                  /* dynamically allocated editor actions */
 	lua_State *lua;                      /* lua context used for syntax highlighting */
 	enum TextLoadMethod load_method;     /* how existing files should be loaded */
-	VisEvent *event;
 	Array operators;
 	Array motions;
 	Array textobjects;
@@ -268,8 +267,9 @@ Mode *mode_get(Vis*, enum VisMode);
 void mode_set(Vis *vis, Mode *new_mode);
 Macro *macro_get(Vis *vis, enum VisRegister);
 
-void window_selection_save(Win *win);
 Win *window_new_file(Vis*, File*, enum UiOption);
+void window_selection_save(Win *win);
+void window_status_update(Vis *vis, Win *win);
 
 char *absolute_path(const char *path);
 

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -1384,7 +1384,7 @@ static int vis_index(lua_State *L) {
 		}
 
 		if (strcmp(key, "count") == 0) {
-			int count = vis_count_get(vis);
+			int count = vis->action.count;
 			if (count == VIS_COUNT_UNKNOWN)
 				lua_pushnil(L);
 			else
@@ -1467,7 +1467,7 @@ static int vis_newindex(lua_State *L) {
 				count = VIS_COUNT_UNKNOWN;
 			else
 				count = luaL_checkunsigned(L, 3);
-			vis_count_set(vis, count);
+			vis->action.count = count;
 			return 0;
 		}
 
@@ -1788,12 +1788,12 @@ static int window_index(lua_State *L) {
 		}
 
 		if (strcmp(key, "width") == 0) {
-			lua_pushunsigned(L, vis_window_width_get(win));
+			lua_pushunsigned(L, win->ui->window_width(win->ui));
 			return 1;
 		}
 
 		if (strcmp(key, "height") == 0) {
-			lua_pushunsigned(L, vis_window_height_get(win));
+			lua_pushunsigned(L, win->ui->window_height(win->ui));
 			return 1;
 		}
 
@@ -2050,7 +2050,7 @@ static int window_style_pos(lua_State *L) {
 static int window_status(lua_State *L) {
 	Win *win = obj_ref_check(L, 1, VIS_LUA_TYPE_WINDOW);
 	char status[1024] = "";
-	int width = vis_window_width_get(win);
+	int width = win->ui->window_width(win->ui);
 	const char *left = luaL_checkstring(L, 2);
 	const char *right = luaL_optstring(L, 3, "");
 	int left_width = text_string_width(left, strlen(left));

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -1788,12 +1788,12 @@ static int window_index(lua_State *L) {
 		}
 
 		if (strcmp(key, "width") == 0) {
-			lua_pushunsigned(L, win->ui->window_width(win->ui));
+			lua_pushunsigned(L, win->ui->width);
 			return 1;
 		}
 
 		if (strcmp(key, "height") == 0) {
-			lua_pushunsigned(L, win->ui->window_height(win->ui));
+			lua_pushunsigned(L, win->ui->height);
 			return 1;
 		}
 
@@ -1827,7 +1827,7 @@ static int window_index(lua_State *L) {
 }
 
 static int window_options_assign(Win *win, lua_State *L, const char *key, int next) {
-	enum UiOption flags = view_options_get(win->view);
+	enum UiOption flags = UI_OPTIONS_GET(win->view->ui);
 	if (strcmp(key, "breakat") == 0 || strcmp(key, "brk") == 0) {
 		if (lua_isstring(L, next))
 			view_breakat_set(win->view, lua_tostring(L, next));
@@ -1988,7 +1988,7 @@ static int window_style_define(lua_State *L) {
 	Win *win = obj_ref_check(L, 1, VIS_LUA_TYPE_WINDOW);
 	enum UiStyle id = luaL_checkunsigned(L, 2);
 	const char *style = luaL_checkstring(L, 3);
-	bool ret = view_style_define(win->view, id, style);
+	bool ret = ui_style_define(win->view->ui, id, style);
 	lua_pushboolean(L, ret);
 	return 1;
 }
@@ -2035,7 +2035,7 @@ static int window_style_pos(lua_State *L) {
 	enum UiStyle style = luaL_checkunsigned(L, 2);
 	size_t x = checkpos(L, 3);
 	size_t y = checkpos(L, 4);
-	bool ret = win->ui->style_set_pos(win->ui, (int)x, (int)y, style);
+	bool ret = ui_window_style_set_pos(win->ui, (int)x, (int)y, style);
 	lua_pushboolean(L, ret);
 	return 1;
 }
@@ -2050,7 +2050,7 @@ static int window_style_pos(lua_State *L) {
 static int window_status(lua_State *L) {
 	Win *win = obj_ref_check(L, 1, VIS_LUA_TYPE_WINDOW);
 	char status[1024] = "";
-	int width = win->ui->window_width(win->ui);
+	int width = win->ui->width;
 	const char *left = luaL_checkstring(L, 2);
 	const char *right = luaL_optstring(L, 3, "");
 	int left_width = text_string_width(left, strlen(left));
@@ -2059,7 +2059,7 @@ static int window_status(lua_State *L) {
 	if (spaces < 1)
 		spaces = 1;
 	snprintf(status, sizeof(status)-1, "%s%*s%s", left, spaces, " ", right);
-	vis_window_status(win, status);
+	ui_window_status(win->ui, status);
 	return 0;
 }
 
@@ -2148,31 +2148,31 @@ static int window_options_index(lua_State *L) {
 			lua_pushunsigned(L, win->view->colorcolumn);
 			return 1;
 		} else if (strcmp(key, "cursorline") == 0 || strcmp(key, "cul") == 0) {
-			lua_pushboolean(L, view_options_get(win->view) & UI_OPTION_CURSOR_LINE);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_CURSOR_LINE);
 			return 1;
 		} else if (strcmp(key, "expandtab") == 0 || strcmp(key, "et") == 0) {
 			lua_pushboolean(L, win->expandtab);
 			return 1;
 		} else if (strcmp(key, "numbers") == 0 || strcmp(key, "nu") == 0) {
-			lua_pushboolean(L, view_options_get(win->view) & UI_OPTION_LINE_NUMBERS_ABSOLUTE);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_LINE_NUMBERS_ABSOLUTE);
 			return 1;
 		} else if (strcmp(key, "relativenumbers") == 0 || strcmp(key, "rnu") == 0) {
-			lua_pushboolean(L, view_options_get(win->view) & UI_OPTION_LINE_NUMBERS_RELATIVE);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_LINE_NUMBERS_RELATIVE);
 			return 1;
 		} else if (strcmp(key, "showeof") == 0) {
-			lua_pushboolean(L, view_options_get(win->view) & UI_OPTION_SYMBOL_EOF);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_SYMBOL_EOF);
 			return 1;
 		} else if (strcmp(key, "shownewlines") == 0) {
-			lua_pushboolean(L, view_options_get(win->view) & UI_OPTION_SYMBOL_EOL);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_SYMBOL_EOL);
 			return 1;
 		} else if (strcmp(key, "showspaces") == 0) {
-			lua_pushboolean(L, view_options_get(win->view) & UI_OPTION_SYMBOL_SPACE);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_SYMBOL_SPACE);
 			return 1;
 		} else if (strcmp(key, "showtabs") == 0) {
-			lua_pushboolean(L, view_options_get(win->view) & UI_OPTION_SYMBOL_TAB);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_SYMBOL_TAB);
 			return 1;
 		} else if (strcmp(key, "statusbar") == 0) {
-			lua_pushboolean(L, view_options_get(win->view) & UI_OPTION_STATUSBAR);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_STATUSBAR);
 			return 1;
 		} else if (strcmp(key, "tabwidth") == 0 || strcmp(key, "tw") == 0) {
 			lua_pushinteger(L, win->view->tabwidth);

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -1107,7 +1107,7 @@ static bool command_lua(Vis *vis, Win *win, void *data, bool force, const char *
 	if (!obj_ref_new(L, win, VIS_LUA_TYPE_WINDOW))
 		return false;
 	if (!sel)
-		sel = view_selections_primary_get(win->view);
+		sel = view_selections_primary_get(&win->view);
 	if (!obj_lightref_new(L, sel, VIS_LUA_TYPE_SELECTION))
 		return false;
 	pushrange(L, range);
@@ -1766,8 +1766,8 @@ static int window_index(lua_State *L) {
 		if (strcmp(key, "viewport") == 0) {
 			Filerange b = VIEW_VIEWPORT_GET(win->view);
 			Filerange l;
-			l.start = win->view->topline->lineno;
-			l.end   = win->view->lastline->lineno;
+			l.start = win->view.topline->lineno;
+			l.end   = win->view.lastline->lineno;
 
 			lua_createtable(L, 0, 4);
 			lua_pushstring(L, "bytes");
@@ -1777,10 +1777,10 @@ static int window_index(lua_State *L) {
 			pushrange(L, &l);
 			lua_settable(L, -3);
 			lua_pushstring(L, "width");
-			lua_pushunsigned(L, win->view->width);
+			lua_pushunsigned(L, win->view.width);
 			lua_settable(L, -3);
 			lua_pushstring(L, "height");
-			lua_pushunsigned(L, win->view->height);
+			lua_pushunsigned(L, win->view.height);
 			lua_settable(L, -3);
 			return 1;
 		}
@@ -1801,13 +1801,13 @@ static int window_index(lua_State *L) {
 		}
 
 		if (strcmp(key, "selection") == 0) {
-			Selection *sel = view_selections_primary_get(win->view);
+			Selection *sel = view_selections_primary_get(&win->view);
 			obj_lightref_new(L, sel, VIS_LUA_TYPE_SELECTION);
 			return 1;
 		}
 
 		if (strcmp(key, "selections") == 0) {
-			obj_ref_new(L, win->view, VIS_LUA_TYPE_SELECTIONS);
+			obj_ref_new(L, &win->view, VIS_LUA_TYPE_SELECTIONS);
 			return 1;
 		}
 
@@ -1825,64 +1825,64 @@ static int window_index(lua_State *L) {
 }
 
 static int window_options_assign(Win *win, lua_State *L, const char *key, int next) {
-	enum UiOption flags = UI_OPTIONS_GET(win->view->ui);
+	enum UiOption flags = UI_OPTIONS_GET(win->view.ui);
 	if (strcmp(key, "breakat") == 0 || strcmp(key, "brk") == 0) {
 		if (lua_isstring(L, next))
-			view_breakat_set(win->view, lua_tostring(L, next));
+			view_breakat_set(&win->view, lua_tostring(L, next));
 	} else if (strcmp(key, "colorcolumn") == 0 || strcmp(key, "cc") == 0) {
-		win->view->colorcolumn = luaL_checkunsigned(L, next);
+		win->view.colorcolumn = luaL_checkunsigned(L, next);
 	} else if (strcmp(key, "cursorline") == 0 || strcmp(key, "cul") == 0) {
 		if (lua_toboolean(L, next))
 			flags |= UI_OPTION_CURSOR_LINE;
 		else
 			flags &= ~UI_OPTION_CURSOR_LINE;
-		view_options_set(win->view, flags);
+		view_options_set(&win->view, flags);
 	} else if (strcmp(key, "numbers") == 0 || strcmp(key, "nu") == 0) {
 		if (lua_toboolean(L, next))
 			flags |= UI_OPTION_LINE_NUMBERS_ABSOLUTE;
 		else
 			flags &= ~UI_OPTION_LINE_NUMBERS_ABSOLUTE;
-		view_options_set(win->view, flags);
+		view_options_set(&win->view, flags);
 	} else if (strcmp(key, "relativenumbers") == 0 || strcmp(key, "rnu") == 0) {
 		if (lua_toboolean(L, next))
 			flags |= UI_OPTION_LINE_NUMBERS_RELATIVE;
 		else
 			flags &= ~UI_OPTION_LINE_NUMBERS_RELATIVE;
-		view_options_set(win->view, flags);
+		view_options_set(&win->view, flags);
 	} else if (strcmp(key, "showeof") == 0) {
 		if (lua_toboolean(L, next))
 			flags |= UI_OPTION_SYMBOL_EOF;
 		else
 			flags &= ~UI_OPTION_SYMBOL_EOF;
-		view_options_set(win->view, flags);
+		view_options_set(&win->view, flags);
 	} else if (strcmp(key, "shownewlines") == 0) {
 		if (lua_toboolean(L, next))
 			flags |= UI_OPTION_SYMBOL_EOL;
 		else
 			flags &= ~UI_OPTION_SYMBOL_EOL;
-		view_options_set(win->view, flags);
+		view_options_set(&win->view, flags);
 	} else if (strcmp(key, "showspaces") == 0) {
 		if (lua_toboolean(L, next))
 			flags |= UI_OPTION_SYMBOL_SPACE;
 		else
 			flags &= ~UI_OPTION_SYMBOL_SPACE;
-		view_options_set(win->view, flags);
+		view_options_set(&win->view, flags);
 	} else if (strcmp(key, "showtabs") == 0) {
 		if (lua_toboolean(L, next))
 			flags |= UI_OPTION_SYMBOL_TAB;
 		else
 			flags &= ~UI_OPTION_SYMBOL_TAB;
-		view_options_set(win->view, flags);
+		view_options_set(&win->view, flags);
 	} else if (strcmp(key, "statusbar") == 0) {
 		if (lua_toboolean(L, next))
 			flags |= UI_OPTION_STATUSBAR;
 		else
 			flags &= ~UI_OPTION_STATUSBAR;
-		view_options_set(win->view, flags);
+		view_options_set(&win->view, flags);
 	} else if (strcmp(key, "wrapcolumn") == 0 || strcmp(key, "wc") == 0) {
-		win->view->wrapcolumn = luaL_checkunsigned(L, next);
+		win->view.wrapcolumn = luaL_checkunsigned(L, next);
 	} else if (strcmp(key, "tabwidth") == 0 || strcmp(key, "tw") == 0) {
-		view_tabwidth_set(win->view, luaL_checkint(L, next));
+		view_tabwidth_set(&win->view, luaL_checkint(L, next));
 	} else if (strcmp(key, "expandtab") == 0 || strcmp(key, "et") == 0) {
 		win->expandtab = lua_toboolean(L, next);
 	}
@@ -1942,7 +1942,7 @@ static int window_selections_iterator_next(lua_State *L) {
 static int window_selections_iterator(lua_State *L) {
 	Win *win = obj_ref_check(L, 1, VIS_LUA_TYPE_WINDOW);
 	Selection **handle = lua_newuserdata(L, sizeof *handle);
-	*handle = view_selections(win->view);
+	*handle = view_selections(&win->view);
 	lua_pushcclosure(L, window_selections_iterator_next, 1);
 	return 1;
 }
@@ -1986,7 +1986,7 @@ static int window_style_define(lua_State *L) {
 	Win *win = obj_ref_check(L, 1, VIS_LUA_TYPE_WINDOW);
 	enum UiStyle id = luaL_checkunsigned(L, 2);
 	const char *style = luaL_checkstring(L, 3);
-	bool ret = ui_style_define(win->view->ui, id, style);
+	bool ret = ui_style_define(win->view.ui, id, style);
 	lua_pushboolean(L, ret);
 	return 1;
 }
@@ -2008,7 +2008,7 @@ static int window_style(lua_State *L) {
 	enum UiStyle style = luaL_checkunsigned(L, 2);
 	size_t start = checkpos(L, 3);
 	size_t end = checkpos(L, 4);
-	view_style(win->view, style, start, end);
+	view_style(&win->view, style, start, end);
 	return 0;
 }
 
@@ -2068,7 +2068,7 @@ static int window_status(lua_State *L) {
  */
 static int window_draw(lua_State *L) {
 	Win *win = obj_ref_check(L, 1, VIS_LUA_TYPE_WINDOW);
-	view_draw(win->view);
+	view_draw(&win->view);
 	return 0;
 }
 
@@ -2140,43 +2140,43 @@ static int window_options_index(lua_State *L) {
 	if (lua_isstring(L, 2)) {
 		const char *key = lua_tostring(L, 2);
 		if (strcmp(key, "breakat") == 0 || strcmp(key, "brk") == 0) {
-			lua_pushstring(L, win->view->breakat);
+			lua_pushstring(L, win->view.breakat);
 			return 1;
 		} else if (strcmp(key, "colorcolumn") == 0 || strcmp(key, "cc") == 0) {
-			lua_pushunsigned(L, win->view->colorcolumn);
+			lua_pushunsigned(L, win->view.colorcolumn);
 			return 1;
 		} else if (strcmp(key, "cursorline") == 0 || strcmp(key, "cul") == 0) {
-			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_CURSOR_LINE);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view.ui) & UI_OPTION_CURSOR_LINE);
 			return 1;
 		} else if (strcmp(key, "expandtab") == 0 || strcmp(key, "et") == 0) {
 			lua_pushboolean(L, win->expandtab);
 			return 1;
 		} else if (strcmp(key, "numbers") == 0 || strcmp(key, "nu") == 0) {
-			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_LINE_NUMBERS_ABSOLUTE);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view.ui) & UI_OPTION_LINE_NUMBERS_ABSOLUTE);
 			return 1;
 		} else if (strcmp(key, "relativenumbers") == 0 || strcmp(key, "rnu") == 0) {
-			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_LINE_NUMBERS_RELATIVE);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view.ui) & UI_OPTION_LINE_NUMBERS_RELATIVE);
 			return 1;
 		} else if (strcmp(key, "showeof") == 0) {
-			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_SYMBOL_EOF);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view.ui) & UI_OPTION_SYMBOL_EOF);
 			return 1;
 		} else if (strcmp(key, "shownewlines") == 0) {
-			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_SYMBOL_EOL);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view.ui) & UI_OPTION_SYMBOL_EOL);
 			return 1;
 		} else if (strcmp(key, "showspaces") == 0) {
-			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_SYMBOL_SPACE);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view.ui) & UI_OPTION_SYMBOL_SPACE);
 			return 1;
 		} else if (strcmp(key, "showtabs") == 0) {
-			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_SYMBOL_TAB);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view.ui) & UI_OPTION_SYMBOL_TAB);
 			return 1;
 		} else if (strcmp(key, "statusbar") == 0) {
-			lua_pushboolean(L, UI_OPTIONS_GET(win->view->ui) & UI_OPTION_STATUSBAR);
+			lua_pushboolean(L, UI_OPTIONS_GET(win->view.ui) & UI_OPTION_STATUSBAR);
 			return 1;
 		} else if (strcmp(key, "tabwidth") == 0 || strcmp(key, "tw") == 0) {
-			lua_pushinteger(L, win->view->tabwidth);
+			lua_pushinteger(L, win->view.tabwidth);
 			return 1;
 		} else if (strcmp(key, "wrapcolumn") == 0 || strcmp(key, "wc") == 0) {
-			lua_pushunsigned(L, win->view->wrapcolumn);
+			lua_pushunsigned(L, win->view.wrapcolumn);
 			return 1;
 		}
 	}
@@ -3492,7 +3492,7 @@ static void vis_lua_win_close(Vis *vis, Win *win) {
 		obj_ref_new(L, win, VIS_LUA_TYPE_WINDOW);
 		pcall(vis, L, 1, 0);
 	}
-	obj_ref_free(L, win->view);
+	obj_ref_free(L, &win->view);
 	obj_ref_free(L, win);
 	lua_pop(L, 1);
 }

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -2363,7 +2363,7 @@ static int window_selection_index(lua_State *L) {
 		}
 
 		if (strcmp(key, "anchored") == 0) {
-			lua_pushboolean(L, view_selections_anchored(sel));
+			lua_pushboolean(L, sel->anchored);
 			return 1;
 		}
 
@@ -2388,7 +2388,7 @@ static int window_selection_newindex(lua_State *L) {
 			Filerange range = getrange(L, 3);
 			if (text_range_valid(&range)) {
 				view_selections_set(sel, &range);
-				view_selections_anchor(sel, true);
+				sel->anchored = true;
 			} else {
 				view_selection_clear(sel);
 			}
@@ -2396,7 +2396,7 @@ static int window_selection_newindex(lua_State *L) {
 		}
 
 		if (strcmp(key, "anchored") == 0) {
-			view_selections_anchor(sel, lua_toboolean(L, 3));
+			sel->anchored = lua_toboolean(L, 3);
 			return 0;
 		}
 	}

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -54,119 +54,13 @@
 #define debug(...) do { } while (0)
 #endif
 
-static void window_status_update(Vis *vis, Win *win) {
-	char left_parts[4][255] = { "", "", "", "" };
-	char right_parts[4][32] = { "", "", "", "" };
-	char left[sizeof(left_parts)+LENGTH(left_parts)*8];
-	char right[sizeof(right_parts)+LENGTH(right_parts)*8];
-	char status[sizeof(left)+sizeof(right)+1];
-	size_t left_count = 0;
-	size_t right_count = 0;
-
-	View *view = win->view;
-	File *file = win->file;
-	Text *txt = file->text;
-	int width = vis_window_width_get(win);
-	enum UiOption options = view_options_get(view);
-	bool focused = vis->win == win;
-	const char *filename = file_name_get(file);
-	const char *mode = vis->mode->status;
-
-	if (focused && mode)
-		strcpy(left_parts[left_count++], mode);
-
-	snprintf(left_parts[left_count++], sizeof(left_parts[0]), "%s%s%s",
-	         filename ? filename : "[No Name]",
-	         text_modified(txt) ? " [+]" : "",
-	         vis_macro_recording(vis) ? " @": "");
-
-	int count = vis_count_get(vis);
-	const char *keys = buffer_content0(&vis->input_queue);
-	if (keys && keys[0])
-		snprintf(right_parts[right_count++], sizeof(right_parts[0]), "%s", keys);
-	else if (count != VIS_COUNT_UNKNOWN)
-		snprintf(right_parts[right_count++], sizeof(right_parts[0]), "%d", count);
-
-	int sel_count = view_selections_count(view);
-	if (sel_count > 1) {
-		Selection *s = view_selections_primary_get(view);
-		int sel_number = view_selections_number(s) + 1;
-		snprintf(right_parts[right_count++], sizeof(right_parts[0]),
-		         "%d/%d", sel_number, sel_count);
-	}
-
-	size_t size = text_size(txt);
-	size_t pos = view_cursor_get(view);
-	size_t percent = 0;
-	if (size > 0) {
-		double tmp = ((double)pos/(double)size)*100;
-		percent = (size_t)(tmp+1);
-	}
-	snprintf(right_parts[right_count++], sizeof(right_parts[0]),
-	         "%zu%%", percent);
-
-	if (!(options & UI_OPTION_LARGE_FILE)) {
-		Selection *sel = view_selections_primary_get(win->view);
-		size_t line = view_cursors_line(sel);
-		size_t col = view_cursors_col(sel);
-		if (col > UI_LARGE_FILE_LINE_SIZE) {
-			options |= UI_OPTION_LARGE_FILE;
-			view_options_set(win->view, options);
-		}
-		snprintf(right_parts[right_count++], sizeof(right_parts[0]),
-		         "%zu, %zu", line, col);
-	}
-
-	int left_len = snprintf(left, sizeof(left), " %s%s%s%s%s%s%s",
-	         left_parts[0],
-	         left_parts[1][0] ? " » " : "",
-	         left_parts[1],
-	         left_parts[2][0] ? " » " : "",
-	         left_parts[2],
-	         left_parts[3][0] ? " » " : "",
-	         left_parts[3]);
-
-	int right_len = snprintf(right, sizeof(right), "%s%s%s%s%s%s%s ",
-	         right_parts[0],
-	         right_parts[1][0] ? " « " : "",
-	         right_parts[1],
-	         right_parts[2][0] ? " « " : "",
-	         right_parts[2],
-	         right_parts[3][0] ? " « " : "",
-	         right_parts[3]);
-
-	if (left_len < 0 || right_len < 0)
-		return;
-	int left_width = text_string_width(left, left_len);
-	int right_width = text_string_width(right, right_len);
-
-	int spaces = width - left_width - right_width;
-	if (spaces < 1)
-		spaces = 1;
-
-	snprintf(status, sizeof(status), "%s%*s%s", left, spaces, " ", right);
-	vis_window_status(win, status);
-}
 
 #if !CONFIG_LUA
 
 bool vis_lua_path_add(Vis *vis, const char *path) { return true; }
 bool vis_lua_paths_get(Vis *vis, char **lpath, char **cpath) { return false; }
-void vis_lua_init(Vis *vis) { }
-void vis_lua_start(Vis *vis) { }
-void vis_lua_quit(Vis *vis) { }
-void vis_lua_file_open(Vis *vis, File *file) { }
-bool vis_lua_file_save_pre(Vis *vis, File *file, const char *path) { return true; }
-void vis_lua_file_save_post(Vis *vis, File *file, const char *path) { }
-void vis_lua_file_close(Vis *vis, File *file) { }
-void vis_lua_win_open(Vis *vis, Win *win) { }
-void vis_lua_win_close(Vis *vis, Win *win) { }
-void vis_lua_win_highlight(Vis *vis, Win *win) { }
-void vis_lua_win_status(Vis *vis, Win *win) { window_status_update(vis, win); }
-void vis_lua_term_csi(Vis *vis, const long *csi) { }
 void vis_lua_process_response(Vis *vis, const char *name,
                               char *buffer, size_t len, ResponseType rtype) { }
-void vis_lua_ui_draw(Vis *vis) { }
 
 #else
 
@@ -3213,7 +3107,7 @@ static void *alloc_lua(void *ud, void *ptr, size_t osize, size_t nsize) {
  * Can be used to set *global* configuration options.
  * @function init
  */
-void vis_lua_init(Vis *vis) {
+static void vis_lua_init(Vis *vis) {
 	lua_State *L = lua_newstate(alloc_lua, vis);
 	if (!L)
 		return;
@@ -3432,7 +3326,7 @@ void vis_lua_init(Vis *vis) {
  * We are about to process interactive keyboard input.
  * @function start
  */
-void vis_lua_start(Vis *vis) {
+static void vis_lua_start(Vis *vis) {
 	vis_lua_event_call(vis, "start");
 }
 
@@ -3440,7 +3334,7 @@ void vis_lua_start(Vis *vis) {
  * Editor is about to terminate.
  * @function quit
  */
-void vis_lua_quit(Vis *vis) {
+static void vis_lua_quit(Vis *vis) {
 	if (!vis->lua)
 		return;
 	vis_lua_event_call(vis, "quit");
@@ -3471,12 +3365,12 @@ static bool vis_lua_input(Vis *vis, const char *key, size_t len) {
 	return ret;
 }
 
-void vis_lua_mode_insert_input(Vis *vis, const char *key, size_t len) {
+void vis_event_mode_insert_input(Vis *vis, const char *key, size_t len) {
 	if (!vis_lua_input(vis, key, len))
 		vis_insert_key(vis, key, len);
 }
 
-void vis_lua_mode_replace_input(Vis *vis, const char *key, size_t len) {
+void vis_event_mode_replace_input(Vis *vis, const char *key, size_t len) {
 	if (!vis_lua_input(vis, key, len))
 		vis_replace_key(vis, key, len);
 }
@@ -3486,7 +3380,7 @@ void vis_lua_mode_replace_input(Vis *vis, const char *key, size_t len) {
  * @function file_open
  * @tparam File file the file to be opened
  */
-void vis_lua_file_open(Vis *vis, File *file) {
+static void vis_lua_file_open(Vis *vis, File *file) {
 	debug("event: file-open: %s %p %p\n", file->name ? file->name : "unnamed", (void*)file, (void*)file->text);
 	lua_State *L = vis->lua;
 	if (!L)
@@ -3507,7 +3401,7 @@ void vis_lua_file_open(Vis *vis, File *file) {
  * @tparam string path the absolute path to which the file will be written, `nil` if standard output
  * @treturn bool whether the write operation should be proceeded
  */
-bool vis_lua_file_save_pre(Vis *vis, File *file, const char *path) {
+static bool vis_lua_file_save_pre(Vis *vis, File *file, const char *path) {
 	lua_State *L = vis->lua;
 	if (!L)
 		return true;
@@ -3530,7 +3424,7 @@ bool vis_lua_file_save_pre(Vis *vis, File *file, const char *path) {
  * @tparam File file the file which was written
  * @tparam string path the absolute path to which it was written, `nil` if standard output
  */
-void vis_lua_file_save_post(Vis *vis, File *file, const char *path) {
+static void vis_lua_file_save_post(Vis *vis, File *file, const char *path) {
 	lua_State *L = vis->lua;
 	if (!L)
 		return;
@@ -3549,7 +3443,7 @@ void vis_lua_file_save_post(Vis *vis, File *file, const char *path) {
  * @function file_close
  * @tparam File file the file being closed
  */
-void vis_lua_file_close(Vis *vis, File *file) {
+static void vis_lua_file_close(Vis *vis, File *file) {
 	debug("event: file-close: %s %p %p\n", file->name ? file->name : "unnamed", (void*)file, (void*)file->text);
 	lua_State *L = vis->lua;
 	if (!L)
@@ -3571,7 +3465,7 @@ void vis_lua_file_close(Vis *vis, File *file) {
  * @function win_open
  * @tparam Window win the window being opened
  */
-void vis_lua_win_open(Vis *vis, Win *win) {
+static void vis_lua_win_open(Vis *vis, Win *win) {
 	debug("event: win-open: %s %p %p\n", win->file->name ? win->file->name : "unnamed", (void*)win, (void*)win->view);
 	lua_State *L = vis->lua;
 	if (!L)
@@ -3590,7 +3484,7 @@ void vis_lua_win_open(Vis *vis, Win *win) {
  * @function win_close
  * @tparam Window win the window being closed
  */
-void vis_lua_win_close(Vis *vis, Win *win) {
+static void vis_lua_win_close(Vis *vis, Win *win) {
 	debug("event: win-close: %s %p %p\n", win->file->name ? win->file->name : "unnamed", (void*)win, (void*)win->view);
 	lua_State *L = vis->lua;
 	if (!L)
@@ -3612,7 +3506,7 @@ void vis_lua_win_close(Vis *vis, Win *win) {
  * @tparam Window win the window being redrawn
  * @see style
  */
-void vis_lua_win_highlight(Vis *vis, Win *win) {
+static void vis_lua_win_highlight(Vis *vis, Win *win) {
 	lua_State *L = vis->lua;
 	if (!L)
 		return;
@@ -3630,7 +3524,7 @@ void vis_lua_win_highlight(Vis *vis, Win *win) {
  * @tparam Window win the affected window
  * @see status
  */
-void vis_lua_win_status(Vis *vis, Win *win) {
+static void vis_lua_win_status(Vis *vis, Win *win) {
 	lua_State *L = vis->lua;
 	if (!L || win->file->internal) {
 		window_status_update(vis, win);
@@ -3651,7 +3545,7 @@ void vis_lua_win_status(Vis *vis, Win *win) {
  * @function term_csi
  * @param List of CSI parameters
  */
-void vis_lua_term_csi(Vis *vis, const long *csi) {
+static void vis_lua_term_csi(Vis *vis, const long *csi) {
 	lua_State *L = vis->lua;
 	if (!L)
 		return;
@@ -3711,8 +3605,80 @@ void vis_lua_process_response(Vis *vis, const char *name,
  * Use sparingly and check for `nil` values!
  * @function ui_draw
  */
-void vis_lua_ui_draw(Vis *vis) {
+static void vis_lua_ui_draw(Vis *vis) {
 	vis_lua_event_call(vis, "ui_draw");
+}
+
+bool vis_event_emit(Vis *vis, enum VisEvents id, ...) {
+	if (!vis->initialized) {
+		vis->initialized = true;
+		vis->ui->init(vis->ui, vis);
+		vis_lua_init(vis);
+	}
+
+	va_list ap;
+	va_start(ap, id);
+	bool ret = true;
+
+	switch (id) {
+	case VIS_EVENT_INIT:
+		break;
+	case VIS_EVENT_START:
+		vis_lua_start(vis);
+		break;
+	case VIS_EVENT_FILE_OPEN:
+	case VIS_EVENT_FILE_SAVE_PRE:
+	case VIS_EVENT_FILE_SAVE_POST:
+	case VIS_EVENT_FILE_CLOSE:
+	{
+		File *file = va_arg(ap, File*);
+		if (file->internal)
+			break;
+		if (id == VIS_EVENT_FILE_OPEN) {
+			vis_lua_file_open(vis, file);
+		} else if (id == VIS_EVENT_FILE_SAVE_PRE) {
+			const char *path = va_arg(ap, const char*);
+			ret = vis_lua_file_save_pre(vis, file, path);
+		} else if (id == VIS_EVENT_FILE_SAVE_POST) {
+			const char *path = va_arg(ap, const char*);
+			vis_lua_file_save_post(vis, file, path);
+		} else if (id == VIS_EVENT_FILE_CLOSE) {
+			vis_lua_file_close(vis, file);
+		}
+		break;
+	}
+	case VIS_EVENT_WIN_OPEN:
+	case VIS_EVENT_WIN_CLOSE:
+	case VIS_EVENT_WIN_HIGHLIGHT:
+	case VIS_EVENT_WIN_STATUS:
+	{
+		Win *win = va_arg(ap, Win*);
+		if (win->file->internal && id != VIS_EVENT_WIN_STATUS)
+			break;
+		if (id == VIS_EVENT_WIN_OPEN) {
+			vis_lua_win_open(vis, win);
+		} else if (id == VIS_EVENT_WIN_CLOSE) {
+			vis_lua_win_close(vis, win);
+		} else if (id == VIS_EVENT_WIN_HIGHLIGHT) {
+			vis_lua_win_highlight(vis, win);
+		} else if (id == VIS_EVENT_WIN_STATUS) {
+			vis_lua_win_status(vis, win);
+		}
+		break;
+	}
+	case VIS_EVENT_QUIT:
+		vis_lua_quit(vis);
+		break;
+	case VIS_EVENT_TERM_CSI:
+		vis_lua_term_csi(vis, va_arg(ap, const long *));
+		break;
+	case VIS_EVENT_UI_DRAW:
+		vis_lua_ui_draw(vis);
+		break;
+	}
+
+	va_end(ap);
+	return ret;
 }
 
 #endif

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -1766,10 +1766,10 @@ static int window_index(lua_State *L) {
 		const char *key = lua_tostring(L, 2);
 
 		if (strcmp(key, "viewport") == 0) {
-			Filerange b = view_viewport_get(win->view);
+			Filerange b = VIEW_VIEWPORT_GET(win->view);
 			Filerange l;
-			l.start = view_lines_first(win->view)->lineno;
-			l.end = view_lines_last(win->view)->lineno;
+			l.start = win->view->topline->lineno;
+			l.end   = win->view->lastline->lineno;
 
 			lua_createtable(L, 0, 4);
 			lua_pushstring(L, "bytes");
@@ -1779,10 +1779,10 @@ static int window_index(lua_State *L) {
 			pushrange(L, &l);
 			lua_settable(L, -3);
 			lua_pushstring(L, "width");
-			lua_pushunsigned(L, view_width_get(win->view));
+			lua_pushunsigned(L, win->view->width);
 			lua_settable(L, -3);
 			lua_pushstring(L, "height");
-			lua_pushunsigned(L, view_height_get(win->view));
+			lua_pushunsigned(L, win->view->height);
 			lua_settable(L, -3);
 			return 1;
 		}
@@ -1832,7 +1832,7 @@ static int window_options_assign(Win *win, lua_State *L, const char *key, int ne
 		if (lua_isstring(L, next))
 			view_breakat_set(win->view, lua_tostring(L, next));
 	} else if (strcmp(key, "colorcolumn") == 0 || strcmp(key, "cc") == 0) {
-		view_colorcolumn_set(win->view, luaL_checkint(L, next));
+		win->view->colorcolumn = luaL_checkunsigned(L, next);
 	} else if (strcmp(key, "cursorline") == 0 || strcmp(key, "cul") == 0) {
 		if (lua_toboolean(L, next))
 			flags |= UI_OPTION_CURSOR_LINE;
@@ -1882,7 +1882,7 @@ static int window_options_assign(Win *win, lua_State *L, const char *key, int ne
 			flags &= ~UI_OPTION_STATUSBAR;
 		view_options_set(win->view, flags);
 	} else if (strcmp(key, "wrapcolumn") == 0 || strcmp(key, "wc") == 0) {
-		view_wrapcolumn_set(win->view, luaL_checkint(L, next));
+		win->view->wrapcolumn = luaL_checkunsigned(L, next);
 	} else if (strcmp(key, "tabwidth") == 0 || strcmp(key, "tw") == 0) {
 		view_tabwidth_set(win->view, luaL_checkint(L, next));
 	} else if (strcmp(key, "expandtab") == 0 || strcmp(key, "et") == 0) {
@@ -2142,10 +2142,10 @@ static int window_options_index(lua_State *L) {
 	if (lua_isstring(L, 2)) {
 		const char *key = lua_tostring(L, 2);
 		if (strcmp(key, "breakat") == 0 || strcmp(key, "brk") == 0) {
-			lua_pushstring(L, view_breakat_get(win->view));
+			lua_pushstring(L, win->view->breakat);
 			return 1;
 		} else if (strcmp(key, "colorcolumn") == 0 || strcmp(key, "cc") == 0) {
-			lua_pushunsigned(L, view_colorcolumn_get(win->view));
+			lua_pushunsigned(L, win->view->colorcolumn);
 			return 1;
 		} else if (strcmp(key, "cursorline") == 0 || strcmp(key, "cul") == 0) {
 			lua_pushboolean(L, view_options_get(win->view) & UI_OPTION_CURSOR_LINE);
@@ -2175,10 +2175,10 @@ static int window_options_index(lua_State *L) {
 			lua_pushboolean(L, view_options_get(win->view) & UI_OPTION_STATUSBAR);
 			return 1;
 		} else if (strcmp(key, "tabwidth") == 0 || strcmp(key, "tw") == 0) {
-			lua_pushinteger(L, view_tabwidth_get(win->view));
+			lua_pushinteger(L, win->view->tabwidth);
 			return 1;
 		} else if (strcmp(key, "wrapcolumn") == 0 || strcmp(key, "wc") == 0) {
-			lua_pushunsigned(L, view_wrapcolumn_get(win->view));
+			lua_pushunsigned(L, win->view->wrapcolumn);
 			return 1;
 		}
 	}
@@ -2203,7 +2203,7 @@ static const struct luaL_Reg window_option_funcs[] = {
 static int window_selections_index(lua_State *L) {
 	View *view = obj_ref_check(L, 1, VIS_LUA_TYPE_SELECTIONS);
 	size_t index = luaL_checkunsigned(L, 2);
-	size_t count = view_selections_count(view);
+	size_t count = view->selection_count;
 	if (index == 0 || index > count)
 		goto err;
 	for (Selection *s = view_selections(view); s; s = view_selections_next(s)) {
@@ -2219,7 +2219,7 @@ err:
 
 static int window_selections_len(lua_State *L) {
 	View *view = obj_ref_check(L, 1, VIS_LUA_TYPE_SELECTIONS);
-	lua_pushunsigned(L, view_selections_count(view));
+	lua_pushunsigned(L, view->selection_count);
 	return 1;
 }
 

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -1399,7 +1399,7 @@ static int vis_index(lua_State *L) {
 		}
 
 		if (strcmp(key, "registers") == 0) {
-			obj_ref_new(L, vis->ui, VIS_LUA_TYPE_REGISTERS);
+			obj_ref_new(L, &vis->ui, VIS_LUA_TYPE_REGISTERS);
 			return 1;
 		}
 
@@ -1415,7 +1415,7 @@ static int vis_index(lua_State *L) {
 		}
 
 		if (strcmp(key, "ui") == 0) {
-			obj_ref_new(L, vis->ui, VIS_LUA_TYPE_UI);
+			obj_ref_new(L, &vis->ui, VIS_LUA_TYPE_UI);
 			return 1;
 		}
 	}
@@ -1429,8 +1429,7 @@ static int vis_options_assign(Vis *vis, lua_State *L, const char *key, int next)
 	} else if (strcmp(key, "changecolors") == 0) {
 		vis->change_colors = lua_toboolean(L, next);
 	} else if (strcmp(key, "escdelay") == 0) {
-		TermKey *tk = vis->ui->termkey;
-		termkey_set_waittime(tk, luaL_checkint(L, next));
+		termkey_set_waittime(vis->ui.termkey, luaL_checkint(L, next));
 	} else if (strcmp(key, "ignorecase") == 0 || strcmp(key, "ic") == 0) {
 		vis->ignorecase = lua_toboolean(L, next);
 	} else if (strcmp(key, "loadmethod") == 0) {
@@ -1570,8 +1569,7 @@ static int vis_options_index(lua_State *L) {
 			lua_pushboolean(L, vis->change_colors);
 			return 1;
 		} else if (strcmp(key, "escdelay") == 0) {
-			TermKey *tk = vis->ui->termkey;
-			lua_pushunsigned(L, termkey_get_waittime(tk));
+			lua_pushunsigned(L, termkey_get_waittime(vis->ui.termkey));
 			return 1;
 		} else if (strcmp(key, "ignorecase") == 0 || strcmp(key, "ic") == 0) {
 			lua_pushboolean(L, vis->ignorecase);
@@ -3612,7 +3610,7 @@ static void vis_lua_ui_draw(Vis *vis) {
 bool vis_event_emit(Vis *vis, enum VisEvents id, ...) {
 	if (!vis->initialized) {
 		vis->initialized = true;
-		ui_init(vis->ui, vis);
+		ui_init(&vis->ui, vis);
 		vis_lua_init(vis);
 	}
 

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -1429,7 +1429,7 @@ static int vis_options_assign(Vis *vis, lua_State *L, const char *key, int next)
 	} else if (strcmp(key, "changecolors") == 0) {
 		vis->change_colors = lua_toboolean(L, next);
 	} else if (strcmp(key, "escdelay") == 0) {
-		TermKey *tk = vis->ui->termkey_get(vis->ui);
+		TermKey *tk = vis->ui->termkey;
 		termkey_set_waittime(tk, luaL_checkint(L, next));
 	} else if (strcmp(key, "ignorecase") == 0 || strcmp(key, "ic") == 0) {
 		vis->ignorecase = lua_toboolean(L, next);
@@ -1570,7 +1570,7 @@ static int vis_options_index(lua_State *L) {
 			lua_pushboolean(L, vis->change_colors);
 			return 1;
 		} else if (strcmp(key, "escdelay") == 0) {
-			TermKey *tk = vis->ui->termkey_get(vis->ui);
+			TermKey *tk = vis->ui->termkey;
 			lua_pushunsigned(L, termkey_get_waittime(tk));
 			return 1;
 		} else if (strcmp(key, "ignorecase") == 0 || strcmp(key, "ic") == 0) {
@@ -1633,7 +1633,7 @@ static int ui_index(lua_State *L) {
 		const char *key  = lua_tostring(L, 2);
 
 		if (strcmp(key, "layout") == 0) {
-			lua_pushunsigned(L, ui_layout_get(ui));
+			lua_pushunsigned(L, ui->layout);
 			return 1;
 		}
 	}
@@ -1648,7 +1648,7 @@ static int ui_newindex(lua_State *L) {
 		const char *key  = lua_tostring(L, 2);
 
 		if (strcmp(key, "layout") == 0) {
-			ui->arrange(ui, luaL_checkint(L, 3));
+			ui_arrange(ui, luaL_checkint(L, 3));
 			return 0;
 		}
 	}
@@ -3260,7 +3260,7 @@ static void vis_lua_init(Vis *vis) {
 
 	obj_type_new(L, VIS_LUA_TYPE_UI);
 	luaL_setfuncs(L, ui_funcs, 0);
-	lua_pushunsigned(L, vis->ui->colors(vis->ui));
+	lua_pushunsigned(L, ui_terminal_colors());
 	lua_setfield(L, -2, "colors");
 	lua_newtable(L);
 	static const struct {
@@ -3612,7 +3612,7 @@ static void vis_lua_ui_draw(Vis *vis) {
 bool vis_event_emit(Vis *vis, enum VisEvents id, ...) {
 	if (!vis->initialized) {
 		vis->initialized = true;
-		vis->ui->init(vis->ui, vis);
+		ui_init(vis->ui, vis);
 		vis_lua_init(vis);
 	}
 

--- a/vis-lua.h
+++ b/vis-lua.h
@@ -22,26 +22,13 @@ bool vis_lua_path_add(Vis*, const char *path);
 bool vis_lua_paths_get(Vis*, char **lpath, char **cpath);
 
 /* various event handlers, triggered by the vis core */
-void vis_lua_init(Vis*);
-void vis_lua_start(Vis*);
-void vis_lua_quit(Vis*);
 #if !CONFIG_LUA
-#define vis_lua_mode_insert_input vis_insert_key
-#define vis_lua_mode_replace_input vis_replace_key
+#define vis_event_mode_insert_input  vis_insert_key
+#define vis_event_mode_replace_input vis_replace_key
 #else
-void vis_lua_mode_insert_input(Vis*, const char *key, size_t len);
-void vis_lua_mode_replace_input(Vis*, const char *key, size_t len);
+void vis_event_mode_insert_input(Vis*, const char *key, size_t len);
+void vis_event_mode_replace_input(Vis*, const char *key, size_t len);
 #endif
-void vis_lua_file_open(Vis*, File*);
-bool vis_lua_file_save_pre(Vis*, File*, const char *path);
-void vis_lua_file_save_post(Vis*, File*, const char *path);
-void vis_lua_file_close(Vis*, File*);
-void vis_lua_win_open(Vis*, Win*);
-void vis_lua_win_close(Vis*, Win*);
-void vis_lua_win_highlight(Vis*, Win*);
-void vis_lua_win_status(Vis*, Win*);
-void vis_lua_term_csi(Vis*, const long *);
 void vis_lua_process_response(Vis *, const char *, char *, size_t, ResponseType);
-void vis_lua_ui_draw(Vis*);
 
 #endif

--- a/vis-marks.c
+++ b/vis-marks.c
@@ -72,12 +72,11 @@ static Array mark_get(Win *win, Array *mark) {
 	array_init_sized(&sel, sizeof(Filerange));
 	if (!mark)
 		return sel;
-	View *view = win->view;
 	size_t len = array_length(mark);
 	array_reserve(&sel, len);
 	for (size_t i = 0; i < len; i++) {
 		SelectionRegion *sr = array_get(mark, i);
-		Filerange r = view_regions_restore(view, sr);
+		Filerange r = view_regions_restore(&win->view, sr);
 		if (text_range_valid(&r))
 			array_add(&sel, &r);
 	}
@@ -93,11 +92,10 @@ static void mark_set(Win *win, Array *mark, Array *sel) {
 	if (!mark)
 		return;
 	array_clear(mark);
-	View *view = win->view;
 	for (size_t i = 0, len = array_length(sel); i < len; i++) {
 		SelectionRegion ss;
 		Filerange *r = array_get(sel, i);
-		if (view_regions_save(view, r, &ss))
+		if (view_regions_save(&win->view, r, &ss))
 			array_add(mark, &ss);
 	}
 }
@@ -150,15 +148,14 @@ static bool marklist_push(Win *win, MarkList *list, Array *sel) {
 }
 
 bool vis_jumplist_save(Vis *vis) {
-	View *view = vis->win->view;
-	Array sel = view_selections_get_all(view);
+	Array sel = view_selections_get_all(&vis->win->view);
 	bool ret = marklist_push(vis->win, &vis->win->jumplist, &sel);
 	array_release(&sel);
 	return ret;
 }
 
 static bool marklist_prev(Win *win, MarkList *list) {
-	View *view = win->view;
+	View *view = &win->view;
 	bool restore = false;
 	Array cur = view_selections_get_all(view);
 	bool anchored = view_selections_primary_get(view)->anchored;
@@ -191,7 +188,7 @@ out:
 }
 
 static bool marklist_next(Win *win, MarkList *list) {
-	View *view = win->view;
+	View *view = &win->view;
 	bool anchored = view_selections_primary_get(view)->anchored;
 	for (;;) {
 		Array *next = array_pop(&list->next);

--- a/vis-marks.c
+++ b/vis-marks.c
@@ -161,7 +161,7 @@ static bool marklist_prev(Win *win, MarkList *list) {
 	View *view = win->view;
 	bool restore = false;
 	Array cur = view_selections_get_all(view);
-	bool anchored = view_selections_anchored(view_selections_primary_get(view));
+	bool anchored = view_selections_primary_get(view)->anchored;
 	Array *top = array_peek(&list->prev);
 	if (!top)
 		goto out;
@@ -192,7 +192,7 @@ out:
 
 static bool marklist_next(Win *win, MarkList *list) {
 	View *view = win->view;
-	bool anchored = view_selections_anchored(view_selections_primary_get(view));
+	bool anchored = view_selections_primary_get(view)->anchored;
 	for (;;) {
 		Array *next = array_pop(&list->next);
 		if (!next)

--- a/vis-modes.c
+++ b/vis-modes.c
@@ -190,7 +190,7 @@ static void vis_mode_visual_enter(Vis *vis, Mode *old) {
 	Win *win = vis->win;
 	if (!old->visual && win) {
 		for (Selection *s = view_selections(win->view); s; s = view_selections_next(s))
-			view_selections_anchor(s, true);
+			s->anchored = true;
 	}
 }
 
@@ -198,7 +198,7 @@ static void vis_mode_visual_line_enter(Vis *vis, Mode *old) {
 	Win *win = vis->win;
 	if (!old->visual && win) {
 		for (Selection *s = view_selections(win->view); s; s = view_selections_next(s))
-			view_selections_anchor(s, true);
+			s->anchored = true;
 	}
 	if (!vis->action.op)
 		vis_motion(vis, VIS_MOVE_NOP);
@@ -213,7 +213,7 @@ static void vis_mode_visual_line_leave(Vis *vis, Mode *new) {
 			window_selection_save(win);
 		view_selections_clear_all(win->view);
 	} else {
-		view_cursor_to(win->view, view_cursor_get(win->view));
+		view_cursors_to(win->view->selection, view_cursor_get(win->view));
 	}
 }
 

--- a/vis-modes.c
+++ b/vis-modes.c
@@ -148,7 +148,7 @@ static void vis_mode_normal_enter(Vis *vis, Mode *old) {
 		return;
 	if (vis->autoindent && strcmp(vis->key_prev, "<Enter>") == 0) {
 		Text *txt = win->file->text;
-		for (Selection *s = view_selections(win->view); s; s = view_selections_next(s)) {
+		for (Selection *s = view_selections(&win->view); s; s = view_selections_next(s)) {
 			size_t pos = view_cursors_pos(s);
 			size_t start = text_line_start(txt, pos);
 			size_t end = text_line_end(txt, pos);
@@ -189,7 +189,7 @@ static void vis_mode_operator_input(Vis *vis, const char *str, size_t len) {
 static void vis_mode_visual_enter(Vis *vis, Mode *old) {
 	Win *win = vis->win;
 	if (!old->visual && win) {
-		for (Selection *s = view_selections(win->view); s; s = view_selections_next(s))
+		for (Selection *s = view_selections(&win->view); s; s = view_selections_next(s))
 			s->anchored = true;
 	}
 }
@@ -197,7 +197,7 @@ static void vis_mode_visual_enter(Vis *vis, Mode *old) {
 static void vis_mode_visual_line_enter(Vis *vis, Mode *old) {
 	Win *win = vis->win;
 	if (!old->visual && win) {
-		for (Selection *s = view_selections(win->view); s; s = view_selections_next(s))
+		for (Selection *s = view_selections(&win->view); s; s = view_selections_next(s))
 			s->anchored = true;
 	}
 	if (!vis->action.op)
@@ -211,9 +211,9 @@ static void vis_mode_visual_line_leave(Vis *vis, Mode *new) {
 	if (!new->visual) {
 		if (!vis->action.op)
 			window_selection_save(win);
-		view_selections_clear_all(win->view);
+		view_selections_clear_all(&win->view);
 	} else {
-		view_cursors_to(win->view->selection, view_cursor_get(win->view));
+		view_cursors_to(win->view.selection, view_cursor_get(&win->view));
 	}
 }
 
@@ -222,7 +222,7 @@ static void vis_mode_visual_leave(Vis *vis, Mode *new) {
 	if (!new->visual && win) {
 		if (!vis->action.op)
 			window_selection_save(win);
-		view_selections_clear_all(win->view);
+		view_selections_clear_all(&win->view);
 	}
 }
 

--- a/vis-motions.c
+++ b/vis-motions.c
@@ -69,7 +69,7 @@ static size_t common_word_next(Vis *vis, Text *txt, size_t pos,
 	if (!text_iterator_byte_get(&it, &c))
 		return pos;
 	const Movement *motion = NULL;
-	int count = vis_count_get_default(vis, 1);
+	int count = VIS_COUNT_DEFAULT(vis->action.count, 1);
 	if (isspace((unsigned char)c)) {
 		motion = &vis_motions[start_next];
 	} else if (!isboundary((unsigned char)c) && text_iterator_char_next(&it, &c) && isboundary((unsigned char)c)) {
@@ -175,7 +175,7 @@ static size_t firstline(Text *txt, size_t pos) {
 }
 
 static size_t line(Vis *vis, Text *txt, size_t pos) {
-	int count = vis_count_get_default(vis, 1);
+	int count = VIS_COUNT_DEFAULT(vis->action.count, 1);
 	return text_line_start(txt, text_pos_by_lineno(txt, count));
 }
 
@@ -185,11 +185,11 @@ static size_t lastline(Text *txt, size_t pos) {
 }
 
 static size_t column(Vis *vis, Text *txt, size_t pos) {
-	return text_line_offset(txt, pos, vis_count_get_default(vis, 0));
+	return text_line_offset(txt, pos, VIS_COUNT_DEFAULT(vis->action.count, 0));
 }
 
 static size_t view_lines_top(Vis *vis, View *view) {
-	return view_screenline_goto(view, vis_count_get_default(vis, 1));
+	return view_screenline_goto(view, VIS_COUNT_DEFAULT(vis->action.count, 1));
 }
 
 static size_t view_lines_middle(Vis *vis, View *view) {
@@ -199,7 +199,7 @@ static size_t view_lines_middle(Vis *vis, View *view) {
 
 static size_t view_lines_bottom(Vis *vis, View *view) {
 	int h = view_height_get(vis->win->view);
-	return view_screenline_goto(vis->win->view, h - vis_count_get_default(vis, 0));
+	return view_screenline_goto(vis->win->view, h - VIS_COUNT_DEFAULT(vis->action.count, 0));
 }
 
 static size_t window_nop(Vis *vis, Win *win, size_t pos) {
@@ -233,25 +233,25 @@ static size_t bracket_match(Text *txt, size_t pos) {
 }
 
 static size_t percent(Vis *vis, Text *txt, size_t pos) {
-	int ratio = vis_count_get_default(vis, 0);
+	int ratio = VIS_COUNT_DEFAULT(vis->action.count, 0);
 	if (ratio > 100)
 		ratio = 100;
 	return text_size(txt) * ratio / 100;
 }
 
 static size_t byte(Vis *vis, Text *txt, size_t pos) {
-	pos = vis_count_get_default(vis, 0);
+	pos = VIS_COUNT_DEFAULT(vis->action.count, 0);
 	size_t max = text_size(txt);
 	return pos <= max ? pos : max;
 }
 
 static size_t byte_left(Vis *vis, Text *txt, size_t pos) {
-	size_t off = vis_count_get_default(vis, 1);
+	size_t off = VIS_COUNT_DEFAULT(vis->action.count, 1);
 	return off <= pos ? pos-off : 0;
 }
 
 static size_t byte_right(Vis *vis, Text *txt, size_t pos) {
-	size_t off = vis_count_get_default(vis, 1);
+	size_t off = VIS_COUNT_DEFAULT(vis->action.count, 1);
 	size_t new = pos + off;
 	size_t max = text_size(txt);
 	return new <= max && new > pos ? new : max;

--- a/vis-motions.c
+++ b/vis-motions.c
@@ -193,13 +193,13 @@ static size_t view_lines_top(Vis *vis, View *view) {
 }
 
 static size_t view_lines_middle(Vis *vis, View *view) {
-	int h = view_height_get(view);
+	int h = view->height;
 	return view_screenline_goto(view, h/2);
 }
 
 static size_t view_lines_bottom(Vis *vis, View *view) {
-	int h = view_height_get(vis->win->view);
-	return view_screenline_goto(vis->win->view, h - VIS_COUNT_DEFAULT(vis->action.count, 0));
+	int h = view->height;
+	return view_screenline_goto(view, h - VIS_COUNT_DEFAULT(vis->action.count, 0));
 }
 
 static size_t window_nop(Vis *vis, Win *win, size_t pos) {

--- a/vis-operators.c
+++ b/vis-operators.c
@@ -102,7 +102,7 @@ static size_t op_put(Vis *vis, Text *txt, OperatorContext *c) {
 
 static size_t op_shift_right(Vis *vis, Text *txt, OperatorContext *c) {
 	char spaces[9] = "         ";
-	spaces[MIN(view_tabwidth_get(vis->win->view), LENGTH(spaces) - 1)] = '\0';
+	spaces[MIN(vis->win->view->tabwidth, LENGTH(spaces) - 1)] = '\0';
 	const char *tab = vis->win->expandtab ? spaces : "\t";
 	size_t tablen = strlen(tab);
 	size_t pos = text_line_begin(txt, c->range.end), prev_pos;
@@ -127,7 +127,7 @@ static size_t op_shift_right(Vis *vis, Text *txt, OperatorContext *c) {
 
 static size_t op_shift_left(Vis *vis, Text *txt, OperatorContext *c) {
 	size_t pos = text_line_begin(txt, c->range.end), prev_pos;
-	size_t tabwidth = view_tabwidth_get(vis->win->view), tablen;
+	size_t tabwidth = vis->win->view->tabwidth, tablen;
 	size_t newpos = c->pos;
 
 	/* if range ends at the begin of a line, skip line break */

--- a/vis-operators.c
+++ b/vis-operators.c
@@ -102,7 +102,7 @@ static size_t op_put(Vis *vis, Text *txt, OperatorContext *c) {
 
 static size_t op_shift_right(Vis *vis, Text *txt, OperatorContext *c) {
 	char spaces[9] = "         ";
-	spaces[MIN(vis->win->view->tabwidth, LENGTH(spaces) - 1)] = '\0';
+	spaces[MIN(vis->win->view.tabwidth, LENGTH(spaces) - 1)] = '\0';
 	const char *tab = vis->win->expandtab ? spaces : "\t";
 	size_t tablen = strlen(tab);
 	size_t pos = text_line_begin(txt, c->range.end), prev_pos;
@@ -127,7 +127,7 @@ static size_t op_shift_right(Vis *vis, Text *txt, OperatorContext *c) {
 
 static size_t op_shift_left(Vis *vis, Text *txt, OperatorContext *c) {
 	size_t pos = text_line_begin(txt, c->range.end), prev_pos;
-	size_t tabwidth = vis->win->view->tabwidth, tablen;
+	size_t tabwidth = vis->win->view.tabwidth, tablen;
 	size_t newpos = c->pos;
 
 	/* if range ends at the begin of a line, skip line break */
@@ -161,7 +161,6 @@ static size_t op_shift_left(Vis *vis, Text *txt, OperatorContext *c) {
 }
 
 static size_t op_cursor(Vis *vis, Text *txt, OperatorContext *c) {
-	View *view = vis->win->view;
 	Filerange r = text_range_linewise(txt, &c->range);
 	for (size_t line = text_range_line_first(txt, &r); line != EPOS; line = text_range_line_next(txt, &r, line)) {
 		size_t pos;
@@ -169,7 +168,7 @@ static size_t op_cursor(Vis *vis, Text *txt, OperatorContext *c) {
 			pos = text_line_finish(txt, line);
 		else
 			pos = text_line_start(txt, line);
-		view_selections_new_force(view, pos);
+		view_selections_new_force(&vis->win->view, pos);
 	}
 	return EPOS;
 }

--- a/vis-operators.c
+++ b/vis-operators.c
@@ -272,7 +272,7 @@ bool vis_operator(Vis *vis, enum VisOperator id, ...) {
 	}
 	case VIS_OP_DELETE:
 	{
-		enum VisMode mode = vis_mode_get(vis);
+		enum VisMode mode = vis->mode->id;
 		enum VisRegister reg = vis_register_used(vis);
 		if (reg == VIS_REG_DEFAULT && (mode == VIS_MODE_INSERT || mode == VIS_MODE_REPLACE))
 			vis_register(vis, VIS_REG_BLACKHOLE);

--- a/vis-prompt.c
+++ b/vis-prompt.c
@@ -182,12 +182,8 @@ void vis_prompt_show(Vis *vis, const char *title) {
 void vis_info_show(Vis *vis, const char *msg, ...) {
 	va_list ap;
 	va_start(ap, msg);
-	vis->ui->info(vis->ui, msg, ap);
+	ui_info_show(vis->ui, msg, ap);
 	va_end(ap);
-}
-
-void vis_info_hide(Vis *vis) {
-	vis->ui->info_hide(vis->ui);
 }
 
 void vis_message_show(Vis *vis, const char *msg) {

--- a/vis-prompt.c
+++ b/vis-prompt.c
@@ -182,7 +182,7 @@ void vis_prompt_show(Vis *vis, const char *title) {
 void vis_info_show(Vis *vis, const char *msg, ...) {
 	va_list ap;
 	va_start(ap, msg);
-	ui_info_show(vis->ui, msg, ap);
+	ui_info_show(&vis->ui, msg, ap);
 	va_end(ap);
 }
 

--- a/vis-prompt.c
+++ b/vis-prompt.c
@@ -54,7 +54,7 @@ static const char *prompt_enter(Vis *vis, const char *keys, const Arg *arg) {
 	Win *win = prompt->parent;
 	char *cmd = NULL;
 
-	Filerange range = view_selection_get(view);
+	Filerange range = view_selections_get(view->selection);
 	if (!vis->mode->visual) {
 		const char *pattern = NULL;
 		Regex *regex = text_regex_new();
@@ -202,6 +202,6 @@ void vis_message_show(Vis *vis, const char *msg) {
 	size_t pos = text_size(txt);
 	text_appendf(txt, "%s\n", msg);
 	text_save(txt, NULL);
-	view_cursor_to(win->view, pos);
+	view_cursors_to(win->view->selection, pos);
 	vis_window_focus(win);
 }

--- a/vis-prompt.c
+++ b/vis-prompt.c
@@ -114,7 +114,7 @@ static const char *prompt_enter(Vis *vis, const char *keys, const Arg *arg) {
 
 static const char *prompt_esc(Vis *vis, const char *keys, const Arg *arg) {
 	Win *prompt = vis->win;
-	if (view_selections_count(prompt->view) > 1) {
+	if (prompt->view->selection_count > 1) {
 		view_selections_dispose_all(prompt->view);
 	} else {
 		prompt_restore(prompt);

--- a/vis-prompt.c
+++ b/vis-prompt.c
@@ -49,7 +49,7 @@ static void prompt_restore(Win *win) {
 
 static const char *prompt_enter(Vis *vis, const char *keys, const Arg *arg) {
 	Win *prompt = vis->win;
-	View *view = prompt->view;
+	View *view = &prompt->view;
 	Text *txt = prompt->file->text;
 	Win *win = prompt->parent;
 	char *cmd = NULL;
@@ -114,8 +114,8 @@ static const char *prompt_enter(Vis *vis, const char *keys, const Arg *arg) {
 
 static const char *prompt_esc(Vis *vis, const char *keys, const Arg *arg) {
 	Win *prompt = vis->win;
-	if (prompt->view->selection_count > 1) {
-		view_selections_dispose_all(prompt->view);
+	if (prompt->view.selection_count > 1) {
+		view_selections_dispose_all(&prompt->view);
 	} else {
 		prompt_restore(prompt);
 		prompt_hide(prompt);
@@ -126,7 +126,7 @@ static const char *prompt_esc(Vis *vis, const char *keys, const Arg *arg) {
 static const char *prompt_up(Vis *vis, const char *keys, const Arg *arg) {
 	vis_motion(vis, VIS_MOVE_LINE_UP);
 	vis_window_mode_unmap(vis->win, VIS_MODE_INSERT, "<Up>");
-	view_options_set(vis->win->view, UI_OPTION_SYMBOL_EOF);
+	view_options_set(&vis->win->view, UI_OPTION_SYMBOL_EOF);
 	return keys;
 }
 
@@ -164,7 +164,7 @@ void vis_prompt_show(Vis *vis, const char *title) {
 		return;
 	Text *txt = prompt->file->text;
 	text_appendf(txt, "%s\n", title);
-	Selection *sel = view_selections_primary_get(prompt->view);
+	Selection *sel = view_selections_primary_get(&prompt->view);
 	view_cursors_scroll_to(sel, text_size(txt)-1);
 	prompt->parent = active;
 	prompt->parent_mode = vis->mode;
@@ -198,6 +198,6 @@ void vis_message_show(Vis *vis, const char *msg) {
 	size_t pos = text_size(txt);
 	text_appendf(txt, "%s\n", msg);
 	text_save(txt, NULL);
-	view_cursors_to(win->view->selection, pos);
+	view_cursors_to(win->view.selection, pos);
 	vis_window_focus(win);
 }

--- a/vis-registers.c
+++ b/vis-registers.c
@@ -188,7 +188,7 @@ bool register_put_range(Vis *vis, Register *reg, Text *txt, Filerange *range) {
 
 size_t vis_register_count(Vis *vis, Register *reg) {
 	if (reg->type == REGISTER_NUMBER)
-		return vis->win ? view_selections_count(vis->win->view) : 0;
+		return vis->win ? vis->win->view->selection_count : 0;
 	return array_length(&reg->values);
 }
 

--- a/vis-registers.c
+++ b/vis-registers.c
@@ -188,7 +188,7 @@ bool register_put_range(Vis *vis, Register *reg, Text *txt, Filerange *range) {
 
 size_t vis_register_count(Vis *vis, Register *reg) {
 	if (reg->type == REGISTER_NUMBER)
-		return vis->win ? vis->win->view->selection_count : 0;
+		return vis->win ? vis->win->view.selection_count : 0;
 	return array_length(&reg->values);
 }
 

--- a/vis.c
+++ b/vis.c
@@ -481,14 +481,6 @@ void vis_window_prev(Vis *vis) {
 	vis_window_focus(sel);
 }
 
-int vis_window_width_get(const Win *win) {
-	return win->ui->window_width(win->ui);
-}
-
-int vis_window_height_get(const Win *win) {
-	return win->ui->window_height(win->ui);
-}
-
 void vis_draw(Vis *vis) {
 	for (Win *win = vis->windows; win; win = win->next)
 		view_draw(win->view);
@@ -1461,7 +1453,7 @@ bool vis_macro_replay(Vis *vis, enum VisRegister id) {
 	Macro *macro = macro_get(vis, id);
 	if (!macro || macro == vis->recording)
 		return false;
-	int count = vis_count_get_default(vis, 1);
+	int count = VIS_COUNT_DEFAULT(vis->action.count, 1);
 	vis_cancel(vis);
 	for (int i = 0; i < count; i++)
 		macro_replay(vis, macro);
@@ -1502,25 +1494,11 @@ void vis_repeat(Vis *vis) {
 		vis_file_snapshot(vis, win->file);
 }
 
-int vis_count_get(Vis *vis) {
-	return vis->action.count;
-}
-
-int vis_count_get_default(Vis *vis, int def) {
-	if (vis->action.count == VIS_COUNT_UNKNOWN)
-		return def;
-	return vis->action.count;
-}
-
-void vis_count_set(Vis *vis, int count) {
-	vis->action.count = (count >= 0 ? count : VIS_COUNT_UNKNOWN);
-}
-
 VisCountIterator vis_count_iterator_get(Vis *vis, int def) {
 	return (VisCountIterator) {
 		.vis = vis,
 		.iteration = 0,
-		.count = vis_count_get_default(vis, def),
+		.count = VIS_COUNT_DEFAULT(vis->action.count, def),
 	};
 }
 
@@ -1927,12 +1905,4 @@ Text *vis_text(Vis *vis) {
 View *vis_view(Vis *vis) {
 	Win *win = vis->win;
 	return win ? win->view : NULL;
-}
-
-Win *vis_window(Vis *vis) {
-	return vis->win;
-}
-
-bool vis_get_autoindent(const Vis *vis) {
-	return vis->autoindent;
 }

--- a/vis.c
+++ b/vis.c
@@ -203,7 +203,7 @@ static void window_free(Win *win) {
 			other->parent = NULL;
 	}
 	if (vis->ui)
-		vis->ui->window_free(win->ui);
+		ui_window_free(win->ui);
 	view_free(win->view);
 	for (size_t i = 0; i < LENGTH(win->modes); i++)
 		map_free(win->modes[i].bindings);
@@ -382,7 +382,7 @@ Win *window_new_file(Vis *vis, File *file, enum UiOption options) {
 	win->file = file;
 	win->view = view_new(file->text);
 	win->expandtab = false;
-	win->ui = vis->ui->window_new(vis->ui, win, options);
+	win->ui = ui_window_new(vis->ui, win, options);
 	if (!win->view || !win->ui) {
 		window_free(win);
 		return NULL;
@@ -397,7 +397,7 @@ Win *window_new_file(Vis *vis, File *file, enum UiOption options) {
 	win->next = vis->windows;
 	vis->windows = win;
 	vis->win = win;
-	vis->ui->window_focus(win->ui);
+	ui_window_focus(win->ui);
 	for (size_t i = 0; i < LENGTH(win->modes); i++)
 		win->modes[i].parent = &vis_modes[i];
 	vis_event_emit(vis, VIS_EVENT_WIN_OPEN, win);
@@ -434,7 +434,7 @@ bool vis_window_change_file(Win *win, const char* filename) {
 }
 
 bool vis_window_split(Win *original) {
-	vis_doupdates(original->vis, false);
+	original->vis->ui->doupdate = false;
 	Win *win = window_new_file(original->vis, original->file, UI_OPTION_STATUSBAR);
 	if (!win)
 		return false;
@@ -447,7 +447,7 @@ bool vis_window_split(Win *original) {
 	win->file = original->file;
 	view_options_set(win->view, UI_OPTIONS_GET(original->view->ui));
 	view_cursors_to(win->view->selection, view_cursor_get(original->view));
-	vis_doupdates(win->vis, true);
+	win->vis->ui->doupdate = true;
 	return true;
 }
 
@@ -456,7 +456,7 @@ void vis_window_focus(Win *win) {
 		return;
 	Vis *vis = win->vis;
 	vis->win = win;
-	vis->ui->window_focus(win->ui);
+	ui_window_focus(win->ui);
 }
 
 void vis_window_next(Vis *vis) {
@@ -482,37 +482,21 @@ void vis_draw(Vis *vis) {
 }
 
 void vis_redraw(Vis *vis) {
-	vis->ui->redraw(vis->ui);
-	vis_update(vis);
-}
-
-void vis_update(Vis *vis) {
-	vis->ui->draw(vis->ui);
-}
-
-void vis_suspend(Vis *vis) {
-	vis->ui->suspend(vis->ui);
-}
-
-void vis_resume(Vis *vis) {
-	vis->ui->resume(vis->ui);
-}
-
-void vis_doupdates(Vis *vis, bool doupdate) {
-	vis->ui->doupdates(vis->ui, doupdate);
+	ui_redraw(vis->ui);
+	ui_draw(vis->ui);
 }
 
 bool vis_window_new(Vis *vis, const char *filename) {
 	File *file = file_new(vis, filename, false);
 	if (!file)
 		return false;
-	vis_doupdates(vis, false);
+	vis->ui->doupdate = false;
 	Win *win = window_new_file(vis, file, UI_OPTION_STATUSBAR|UI_OPTION_SYMBOL_EOF);
 	if (!win) {
 		file_free(vis, file);
 		return false;
 	}
-	vis_doupdates(vis, true);
+	vis->ui->doupdate = true;
 
 	return true;
 }
@@ -554,7 +538,7 @@ void vis_window_swap(Win *a, Win *b) {
 		vis->windows = b;
 	else if (vis->windows == b)
 		vis->windows = a;
-	vis->ui->window_swap(a->ui, b->ui);
+	ui_window_swap(a->ui, b->ui);
 	if (vis->win == a)
 		vis_window_focus(b);
 	else if (vis->win == b)
@@ -579,7 +563,7 @@ void vis_window_close(Win *win) {
 		vis->message_window = NULL;
 	window_free(win);
 	if (vis->win)
-		vis->ui->window_focus(vis->win->ui);
+		ui_window_focus(vis->win->ui);
 	vis_draw(vis);
 }
 
@@ -645,7 +629,7 @@ void vis_free(Vis *vis) {
 	file_free(vis, vis->error_file);
 	for (int i = 0; i < LENGTH(vis->registers); i++)
 		register_release(&vis->registers[i]);
-	vis->ui->free(vis->ui);
+	ui_terminal_free(vis->ui);
 	if (vis->usercmds) {
 		const char *name;
 		while (map_first(vis->usercmds, &name) && vis_cmd_unregister(vis, name));
@@ -976,7 +960,7 @@ void vis_cancel(Vis *vis) {
 void vis_die(Vis *vis, const char *msg, ...) {
 	va_list ap;
 	va_start(ap, msg);
-	vis->ui->die(vis->ui, msg, ap);
+	ui_die(vis->ui, msg, ap);
 	va_end(ap);
 }
 
@@ -984,7 +968,7 @@ const char *vis_keys_next(Vis *vis, const char *keys) {
 	if (!keys || !*keys)
 		return NULL;
 	TermKeyKey key;
-	TermKey *termkey = vis->ui->termkey_get(vis->ui);
+	TermKey *termkey = vis->ui->termkey;
 	const char *next = NULL;
 	/* first try to parse a special key of the form <Key> */
 	if (*keys == '<' && keys[1] && (next = termkey_strpkey(termkey, keys+1, &key, TERMKEY_FORMAT_VIM)) && *next == '>')
@@ -1012,7 +996,7 @@ long vis_keys_codepoint(Vis *vis, const char *keys) {
 	long codepoint = -1;
 	const char *next;
 	TermKeyKey key;
-	TermKey *termkey = vis->ui->termkey_get(vis->ui);
+	TermKey *termkey = vis->ui->termkey;
 
 	if (!keys[0])
 		return -1;
@@ -1205,9 +1189,9 @@ static void vis_keys_push(Vis *vis, const char *input, size_t pos, bool record) 
 
 static const char *getkey(Vis *vis) {
 	TermKeyKey key = { 0 };
-	if (!vis->ui->getkey(vis->ui, &key))
+	if (!ui_getkey(vis->ui, &key))
 		return NULL;
-	vis_info_hide(vis);
+	ui_info_hide(vis->ui);
 	bool use_keymap = vis->mode->id != VIS_MODE_INSERT &&
 	                  vis->mode->id != VIS_MODE_REPLACE &&
 	                  !vis->keymap_disabled;
@@ -1221,7 +1205,7 @@ static const char *getkey(Vis *vis) {
 		}
 	}
 
-	TermKey *termkey = vis->ui->termkey_get(vis->ui);
+	TermKey *termkey = vis->ui->termkey;
 	if (key.type == TERMKEY_TYPE_UNKNOWN_CSI) {
 		long args[18];
 		size_t nargs;
@@ -1315,16 +1299,16 @@ int vis_run(Vis *vis) {
 		}
 
 		if (vis->resume) {
-			vis_resume(vis);
+			ui_terminal_resume(vis->ui);
 			vis->resume = false;
 		}
 
 		if (vis->need_resize) {
-			vis->ui->resize(vis->ui);
+			ui_resize(vis->ui);
 			vis->need_resize = false;
 		}
 
-		vis_update(vis);
+		ui_draw(vis->ui);
 		idle.tv_sec = vis->mode->idle_timeout;
 		int r = pselect(vis_process_before_tick(&fds) + 1, &fds, NULL, NULL,
 		                timeout, &emptyset);
@@ -1344,7 +1328,7 @@ int vis_run(Vis *vis) {
 			continue;
 		}
 
-		TermKey *termkey = vis->ui->termkey_get(vis->ui);
+		TermKey *termkey = vis->ui->termkey;
 		termkey_advisereadable(termkey);
 		const char *key;
 
@@ -1640,7 +1624,7 @@ int vis_pipe(Vis *vis, File *file, Filerange *range, const char *argv[],
 		return -1;
 	}
 
-	vis->ui->terminal_save(vis->ui, fullscreen);
+	ui_terminal_save(vis->ui, fullscreen);
 	pid_t pid = fork();
 
 	if (pid == -1) {
@@ -1834,7 +1818,7 @@ err:
 	sigaction(SIGTERM, &sigterm_old, NULL);
 
 	vis->interrupted = false;
-	vis->ui->terminal_restore(vis->ui);
+	ui_terminal_restore(vis->ui);
 
 	if (WIFEXITED(status))
 		return WEXITSTATUS(status);

--- a/vis.h
+++ b/vis.h
@@ -196,8 +196,6 @@ bool vis_window_closable(Win*);
 void vis_window_close(Win*);
 /** Split the window, shares the underlying file object. */
 bool vis_window_split(Win*);
-/** Change status message of this window. */
-void vis_window_status(Win*, const char *status);
 void vis_window_draw(Win*);
 void vis_window_invalidate(Win*);
 /** Focus next window. */

--- a/vis.h
+++ b/vis.h
@@ -110,27 +110,6 @@ void vis_exit(Vis*, int status);
 void vis_die(Vis*, const char *msg, ...) __attribute__((noreturn,format(printf, 2, 3)));
 
 /**
- * Temporarily suspend the editor process.
- * @rst
- * .. note:: This function will generate a ``SIGTSTP`` signal.
- * @endrst
- **/
-void vis_suspend(Vis*);
-/**
- * Resume editor process.
- * @rst
- * .. note:: This function is usually called in response to a ``SIGCONT`` signal.
- * @endrst
- */
-void vis_resume(Vis*);
-/**
- * Set doupdate flag.
- * @rst
- * .. note:: Prevent flickering in curses by delaying window updates.
- * @endrst
- */
-void vis_doupdates(Vis*, bool);
-/**
  * Inform the editor core that a signal occurred.
  * @return Whether the signal was handled.
  * @rst
@@ -162,8 +141,6 @@ bool vis_interrupt_requested(Vis*);
 void vis_draw(Vis*);
 /** Completely redraw user interface. */
 void vis_redraw(Vis*);
-/** Blit user interface state to output device. */
-void vis_update(Vis*);
 /**
  * @}
  * @defgroup vis_windows
@@ -226,8 +203,6 @@ void vis_prompt_show(Vis*, const char *title);
  * @endrst
  */
 void vis_info_show(Vis*, const char *msg, ...) __attribute__((format(printf, 2, 3)));
-/** Hide informational message. */
-void vis_info_hide(Vis*);
 
 /** Display arbitrary long message in a dedicated window. */
 void vis_message_show(Vis*, const char *msg);

--- a/vis.h
+++ b/vis.h
@@ -90,8 +90,8 @@ typedef struct {
  * @defgroup vis_lifecycle
  * @{
  */
-/** Create a new editor instance using the given user interface. */
-Vis *vis_new(Ui*);
+/** Create a new editor instance. */
+Vis *vis_new(void);
 /** Free all resources associated with this editor instance, terminates UI. */
 void vis_free(Vis*);
 /**

--- a/vis.h
+++ b/vis.h
@@ -40,27 +40,6 @@ typedef struct Win Win;
 /* maximum bytes needed for string representation of a (pseudo) key */
 #define VIS_KEY_LENGTH_MAX 64
 
-/**
- * Editor event handlers.
- */
-typedef struct {
-	void (*init)(Vis*);
-	void (*start)(Vis*);
-	void (*quit)(Vis*);
-	void (*mode_insert_input)(Vis*, const char *key, size_t len);
-	void (*mode_replace_input)(Vis*, const char *key, size_t len);
-	void (*file_open)(Vis*, File*);
-	bool (*file_save_pre)(Vis*, File*, const char *path);
-	void (*file_save_post)(Vis*, File*, const char *path);
-	void (*file_close)(Vis*, File*);
-	void (*win_open)(Vis*, Win*);
-	void (*win_close)(Vis*, Win*);
-	void (*win_highlight)(Vis*, Win*);
-	void (*win_status)(Vis*, Win*);
-	void (*term_csi)(Vis*, const long *);
-	void (*ui_draw)(Vis*);
-} VisEvent;
-
 /** Union used to pass arguments to key action functions. */
 typedef union {
 	bool b;
@@ -111,8 +90,8 @@ typedef struct {
  * @defgroup vis_lifecycle
  * @{
  */
-/** Create a new editor instance using the given user interface and event handlers. */
-Vis *vis_new(Ui*, VisEvent*);
+/** Create a new editor instance using the given user interface. */
+Vis *vis_new(Ui*);
 /** Free all resources associated with this editor instance, terminates UI. */
 void vis_free(Vis*);
 /**

--- a/vis.h
+++ b/vis.h
@@ -208,10 +208,6 @@ void vis_window_prev(Vis*);
 void vis_window_focus(Win*);
 /** Swap location of two windows. */
 void vis_window_swap(Win*, Win*);
-/** Query window width. */
-int vis_window_width_get(const Win*);
-/** Query window height. */
-int vis_window_height_get(const Win*);
 /**
  * @}
  * @defgroup vis_info
@@ -294,8 +290,6 @@ enum VisMode {
  * @endrst
  */
 void vis_mode_switch(Vis*, enum VisMode);
-/** Get currently active mode. */
-enum VisMode vis_mode_get(Vis*);
 /** Translate human readable mode name to constant. */
 enum VisMode vis_mode_from(Vis*, const char *name);
 
@@ -560,14 +554,8 @@ int vis_motion_register(Vis*, void *context, VisMotionFunction*);
  */
 /** No count was specified. */
 #define VIS_COUNT_UNKNOWN (-1)
-/** Get count, might return `VIS_COUNT_UNKNOWN`. */
-int vis_count_get(Vis*);
-/** Get count, if none was specified, return ``def``. */
-int vis_count_get_default(Vis*, int def);
-/** Set a count. */
-void vis_count_set(Vis*, int count);
-/** Set the tabwidth */
-void vis_tabwidth_set(Vis*, int tw);
+#define VIS_COUNT_DEFAULT(count, def) ((count) == VIS_COUNT_UNKNOWN ? (def) : (count))
+#define VIS_COUNT_NORMALIZE(count)    ((count) < 0 ? VIS_COUNT_UNKNOWN : (count))
 /** Set the shell */
 void vis_shell_set(Vis*, const char *new_shell);
 
@@ -974,9 +962,5 @@ void vis_file_snapshot(Vis*, File*);
 /* TODO: expose proper API to iterate through files etc */
 Text *vis_text(Vis*);
 View *vis_view(Vis*);
-Win *vis_window(Vis*);
-
-/* Get value of autoindent */
-bool vis_get_autoindent(const Vis*);
 
 #endif


### PR DESCRIPTION
I was growing tired of trying to debug things in vis when everything had to jump through many levels of redirection because all of the core structures were opaque. So I went through and cleaned all that up. While I was at it I shuffled some things around so that now when you want to add a new event to lua you don't need to define a stub function for when lua is disabled.

The only functional change that should have happened is that the QUIT event now happens after all windows have been closed and their files freed. Everything else should be the same as before.

Obviously a 450 line reduction in code is nice and on my system the binary size was also reduced by ~10kB. At runtime there is probably a minor performance benefit and lower memory usage but I didn't really measure those.

I'm still not a fan of how all the header files are interdependent and tangled up but fixing that will have to wait until later.