### PR TITLE
fix primary cursor color display

### DIFF
--- a/vis.c
+++ b/vis.c
@@ -398,7 +398,8 @@ static void window_draw_cursor(Win *win, Selection *cur) {
 	int col = view_cursors_cell_get(cur);
 	if (!line || col == -1)
 		return;
-	win->ui->style_set(win->ui, &line->cells[col], UI_STYLE_CURSOR);
+	Selection *primary = view_selections_primary_get(win->view);
+	win->ui->style_set(win->ui, &line->cells[col], primary == cur ? UI_STYLE_CURSOR_PRIMARY : UI_STYLE_CURSOR);
 	window_draw_cursor_matching(win, cur);
 	return;
 }


### PR DESCRIPTION
Since the last release (v0.9), my theme configuration has stopped working: the color of the primary selection cursor no longer matches the ``lexer.STYLE_CURSOR_PRIMARY`` setting. 

This patch fixes this issue.