### PR TITLE
fix support for incremental rebuilds as set out by 436044

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /config.h
 /config.mk
 /dependency
-/obj
 /vis
 /vis-menu
 /vis-single
@@ -13,3 +12,4 @@
 *.gcov
 *.html
 *.d
+*.o

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ SRC = array.c \
 	vis-text-objects.c \
 	vis.c \
 	$(REGEX_SRC)
-OBJ = $(SRC:%.c=obj/%.o)
+OBJ = $(SRC:%.c=%.o)
 
 ELF = vis vis-menu vis-digraph
 EXECUTABLES = $(ELF) vis-clipboard vis-complete vis-open
@@ -82,16 +82,11 @@ config.h:
 config.mk:
 	@touch $@
 
-obj/.tstamp:
-	mkdir obj
-	touch obj/.tstamp
+.c.o:
+	${CC} ${CFLAGS} ${CFLAGS_VIS} ${CFLAGS_EXTRA} -o $@ -c $<
 
-obj/main.o: config.h
-
-$(OBJ): config.mk obj/.tstamp
-	${CC} ${CFLAGS} ${CFLAGS_VIS} ${CFLAGS_EXTRA} -o $@ -c $(@:obj/%.o=%.c)
-
--include obj/*.d
+-include *.d
+${OBJ}: config.mk config.h
 
 vis: ${OBJ}
 	${CC} -o $@ ${OBJ} ${LDFLAGS} ${LDFLAGS_VIS} ${LDFLAGS_EXTRA}
@@ -157,8 +152,7 @@ testclean:
 
 clean:
 	@echo cleaning
-	@rm -rf obj
-	@rm -f $(ELF) vis-single vis-single-payload.inc vis-*.tar.gz *.gcov *.gcda *.gcno *.d
+	@rm -f $(ELF) $(OBJ) vis-single vis-single-payload.inc vis-*.tar.gz *.gcov *.gcda *.gcno *.d
 
 distclean: clean testclean
 	@echo cleaning build configuration


### PR DESCRIPTION
the POSIX Makefile macro ".c.o"(reintroduced into this patch), for example, compiles text.c -> text.o, if text.o is either older, or it doesn't exist.

this was removed in patches 4ca7119 & 09ba77a, after which, if you modify any C file(except menu & diagraph), vis would not be re-compiled.

the goal of 4ca7119 was to stop the base directory from being polluted with .o & .d files. This patch polluates the base directory.

the only simple alternative to .c.o, which doesn't pollute, is the following:

```
obj/%.o: %.c
	${CC} ${CFLAGS} ${CFLAGS_VIS} -c $< -o $@
```

this is not POSIX, however.