### PR TITLE
ui: add missing includes for printfs

### DIFF
--- a/ui-terminal.c
+++ b/ui-terminal.c
@@ -1,5 +1,7 @@
 #include <unistd.h>
 #include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
 #include <string.h>
 #include <strings.h>
 #include <limits.h>


### PR DESCRIPTION
functions such as [v]snprintf and sscanf require stdio and stdarg.

``
ui-terminal.c:55:2: error: call to undeclared function 'vfprintf'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   55 |         vfprintf(stderr, msg, ap);
      |         ^
ui-terminal.c:55:2: warning: declaration of built-in function 'vfprintf' requires inclusion of the header <stdio.h> [-Wbuiltin-requires-header]
ui-terminal.c:55:11: error: use of undeclared identifier 'stderr'
   55 |         vfprintf(stderr, msg, ap);
      |                  ^
ui-terminal.c:90:11: error: call to undeclared library function 'sscanf' with type 'int (const char *restrict, const char *restrict, ...)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   90 |                 int n = sscanf(s + 1, "%2hhx%2hhx%2hhx", &r, &g, &b);
      |                         ^
ui-terminal.c:90:11: note: include the header <stdio.h> or explicitly provide a declaration for 'sscanf'
ui-terminal.c:230:32: error: call to undeclared library function 'snprintf' with type 'int (char *restrict, unsigned long, const char *restrict, ...)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  230 |         int sidebar_width = sidebar ? snprintf(NULL, 0, "%zd ", line->lineno + height - 2) : 0;
      |                                       ^
ui-terminal.c:230:32: note: include the header <stdio.h> or explicitly provide a declaration for 'snprintf'
cc -O3 -pipe -march=native -Wall -pipe -O2 -ffunction-sections -fdata-sections -fPIE -fstack-protector-all        -std=c99 -U_XOPEN_SOURCE -D_XOPEN_SOURCE=700 -DNDEBUG -MMD -DVERSION=\"630693b\" -DHAVE_MEMRCHR=1 -DVIS_PATH=\"/usr/local/share/vis\" -DCONFIG_HELP=1 -DCONFIG_CURSES=0 -DCONFIG_LUA=0 -DCONFIG_LPEG=0 -DCONFIG_TRE=0 -DCONFIG_SELINUX=0 -DCONFIG_ACL=0  -o obj/vis-lua.o -c vis-lua.c
ui-terminal.c:503:2: error: call to undeclared library function 'vsnprintf' with type 'int (char *restrict, unsigned long, const char *restrict, struct __va_list_tag *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  503 |         vsnprintf(tui->info, sizeof(tui->info), msg, ap);
      |         ^
ui-terminal.c:503:2: note: include the header <stdio.h> or explicitly provide a declaration for 'vsnprintf'
```