### PR TITLE
docs: remove $ from environment variable name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,5 +32,5 @@ body:
       placeholder: "st 0.8.2"
   - type: input
     attributes:
-      label: "$TERM environment variable"
+      label: "TERM environment variable"
       placeholder: "st-256color"


### PR DESCRIPTION
Remove $ from environment variable name because environment variables are referenced by name without it. For example, in man pages.