### PR TITLE
Fix waycopy clipboard hanging 

### DIFF
--- a/vis-clipboard
+++ b/vis-clipboard
@@ -117,9 +117,9 @@ vc_wlclipboard_paste() {
 
 vc_wayclip_copy() {
 	if [ "$sel" = "primary" ]; then
-		waycopy -p
+		waycopy -p 2>/dev/null
 	else
-		waycopy
+		waycopy 2>/dev/null
 	fi
 }
 


### PR DESCRIPTION
A simple modification to fix waycopy hanging due to unclosed stderr fd (see [here](https://github.com/martanne/vis/issues/929))