### PR TITLE
doc/Makefile: add an empty clean target...

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,6 +13,7 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 clean:
+	rm -rf build
 
 .PHONY: help clean Makefile
 


### PR DESCRIPTION
... now that this is made with 12fc09a442939d0af09d700c7a8074cca9b1694e.

This unbreaks `make docker`, which triggered the catch-all target and failed.