### PR TITLE
Simplify and improve usability of jump list

### DIFF
--- a/array.c
+++ b/array.c
@@ -141,21 +141,3 @@ void array_sort(Array *arr, int (*compar)(const void*, const void*)) {
 	if (arr->items)
 		qsort(arr->items, arr->len, arr->elem_size, compar);
 }
-
-bool array_push(Array *arr, void *item) {
-	return array_add(arr, item);
-}
-
-void *array_pop(Array *arr) {
-	void *item = array_peek(arr);
-	if (!item)
-		return NULL;
-	arr->len--;
-	return item;
-}
-
-void *array_peek(const Array *arr) {
-	if (arr->len == 0)
-		return NULL;
-	return array_get(arr, arr->len - 1);
-}

--- a/array.h
+++ b/array.h
@@ -101,26 +101,5 @@ VIS_INTERNAL bool array_resize(Array*, size_t length);
  * Sort array, the comparision function works as for `qsort(3)`.
  */
 VIS_INTERNAL void array_sort(Array*, int (*compar)(const void*, const void*));
-/**
- * Push item onto the top of the stack.
- * @rst
- * .. note:: Is equivalent to ``array_add(arr, item)``.
- * @endrst
- */
-VIS_INTERNAL bool array_push(Array*, void *item);
-/**
- * Get and remove item at the top of the stack.
- * @rst
- * .. warning:: The same ownership rules as for ``array_get`` apply.
- * @endrst
- */
-VIS_INTERNAL void *array_pop(Array*);
-/**
- * Get item at the top of the stack without removing it.
- * @rst
- * .. warning:: The same ownership rules as for ``array_get`` apply.
- * @endrst
- */
-VIS_INTERNAL void *array_peek(const Array*);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -1247,12 +1247,7 @@ static KEY_ACTION_FN(ka_percent)
 
 static KEY_ACTION_FN(ka_jumplist)
 {
-	if (arg->i < 0)
-		vis_jumplist_prev(vis);
-	else if (arg->i > 0)
-		vis_jumplist_next(vis);
-	else
-		vis_jumplist_save(vis);
+	vis_jumplist(vis, arg->i);
 	return keys;
 }
 

--- a/test/core/array-test.c
+++ b/test/core/array-test.c
@@ -22,8 +22,6 @@ static void test_small_objects(void) {
 	ok(arr.len == 0, "Initialization");
 	ok(!array_set(&arr, 0, NULL) && errno == EINVAL, "Set with invalid index");
 	ok(array_get(&arr, 0) == NULL && errno == EINVAL, "Get with invalid index");
-	ok(array_peek(&arr) == NULL && arr.len == 0, "Peek empty array");
-	ok(array_pop(&arr) == NULL && arr.len == 0, "Pop empty array");
 
 	for (size_t i = 0; i < len; i++) {
 		int *v;
@@ -44,11 +42,6 @@ static void test_small_objects(void) {
 			"Get array element: %zu = %d", i, *v);
 	}
 
-	int *v;
-	ok((v = array_peek(&arr)) && *v == values[0] && arr.len == len, "Peek populated array");
-	ok((v = array_pop(&arr)) && *v == values[0] && arr.len == len-1, "Pop populated array");
-	ok((v = array_peek(&arr)) && *v == values[1] && arr.len == len-1, "Peek after pop");
-
 	array_clear(&arr);
 	ok(arr.len == 0 && array_get(&arr, 0) == NULL && errno == EINVAL, "Clear");
 
@@ -66,6 +59,7 @@ static void test_small_objects(void) {
 
 	ok(!array_remove(&arr, arr.len) && errno == EINVAL, "Remove past end of array");
 
+	int *v;
 	size_t len_before = arr.len;
 	ok(array_remove(&arr, 2) && arr.len == len_before-1 &&
 	   (v = array_get(&arr, 0)) && *v == values[0] &&

--- a/vis-core.h
+++ b/vis-core.h
@@ -161,9 +161,18 @@ struct Win {
 	Mode *parent_mode;      /* mode which was active when showing the command prompt */
 	Win *prev, *next;       /* neighbouring windows */
 
-	/* Jumplist LRU */
-	size_t mark_set_lru_cursor;
-	Array  mark_set_lru[32];
+	/* NOTE: Selection Jump Cache
+	 * Anytime the selection jumps the previous set of selections gets
+	 * pushed into this cache. The user can navigate this cache to
+	 * restore old selections and they can save their own selection
+	 * sets into the cache.
+	 *
+	 * IMPORTANT: cursor is not kept in bounds. it is always used modulo VIS_MARK_SET_LRU_COUNT
+	 */
+	#define VIS_MARK_SET_LRU_COUNT (32)
+	size_t       mark_set_lru_cursor;
+	Array        mark_set_lru_regions[VIS_MARK_SET_LRU_COUNT];
+	enum VisMode mark_set_lru_modes[VIS_MARK_SET_LRU_COUNT];
 };
 
 struct Vis {

--- a/vis-core.h
+++ b/vis-core.h
@@ -131,12 +131,6 @@ typedef struct {
 	enum SamError error;  /* non-zero in case something went wrong */
 } Transcript;
 
-typedef struct {
-	Array prev;
-	Array next;
-	size_t max;
-} MarkList;
-
 struct File { /* shared state among windows displaying the same file */
 	Text *text;                      /* data structure holding the file content */
 	const char *name;                /* file name used when loading/saving */
@@ -161,12 +155,15 @@ struct Win {
 	bool expandtab;         /* whether typed tabs should be converted to spaces in this window*/
 	Vis *vis;               /* editor instance to which this window belongs */
 	File *file;             /* file being displayed in this window */
-	MarkList jumplist;      /* LRU jump management */
 	Array saved_selections; /* register used to store selections */
 	Mode modes[VIS_MODE_INVALID]; /* overlay mods used for per window key bindings */
 	Win *parent;            /* window which was active when showing the command prompt */
 	Mode *parent_mode;      /* mode which was active when showing the command prompt */
 	Win *prev, *next;       /* neighbouring windows */
+
+	/* Jumplist LRU */
+	size_t mark_set_lru_cursor;
+	Array  mark_set_lru[32];
 };
 
 struct Vis {
@@ -282,9 +279,6 @@ VIS_INTERNAL void register_release(Register*);
 
 VIS_INTERNAL void mark_init(Array*);
 VIS_INTERNAL void mark_release(Array*);
-
-VIS_INTERNAL void marklist_init(MarkList*, size_t max);
-VIS_INTERNAL void marklist_release(MarkList*);
 
 VIS_INTERNAL const char *register_get(Vis*, Register*, size_t *len);
 VIS_INTERNAL const char *register_slot_get(Vis*, Register*, size_t slot, size_t *len);

--- a/vis.c
+++ b/vis.c
@@ -204,8 +204,8 @@ static void window_free(Win *win) {
 	view_free(&win->view);
 	for (size_t i = 0; i < LENGTH(win->modes); i++)
 		map_free(win->modes[i].bindings);
-	for (int i = 0; i < LENGTH(win->mark_set_lru); i++)
-		free(win->mark_set_lru[i].items);
+	for (int i = 0; i < VIS_MARK_SET_LRU_COUNT; i++)
+		free(win->mark_set_lru_regions[i].items);
 	mark_release(&win->saved_selections);
 	free(win);
 }
@@ -385,8 +385,8 @@ Win *window_new_file(Vis *vis, File *file, enum UiOption options) {
 		return NULL;
 	}
 
-	for (int i = 0; i < LENGTH(win->mark_set_lru); i++)
-		win->mark_set_lru[i].elem_size = sizeof(SelectionRegion);
+	for (int i = 0; i < VIS_MARK_SET_LRU_COUNT; i++)
+		win->mark_set_lru_regions[i].elem_size = sizeof(SelectionRegion);
 
 	mark_init(&win->saved_selections);
 	file->refcount++;

--- a/vis.c
+++ b/vis.c
@@ -204,7 +204,8 @@ static void window_free(Win *win) {
 	view_free(&win->view);
 	for (size_t i = 0; i < LENGTH(win->modes); i++)
 		map_free(win->modes[i].bindings);
-	marklist_release(&win->jumplist);
+	for (int i = 0; i < LENGTH(win->mark_set_lru); i++)
+		free(win->mark_set_lru[i].items);
 	mark_release(&win->saved_selections);
 	free(win);
 }
@@ -383,7 +384,10 @@ Win *window_new_file(Vis *vis, File *file, enum UiOption options) {
 		window_free(win);
 		return NULL;
 	}
-	marklist_init(&win->jumplist, 32);
+
+	for (int i = 0; i < LENGTH(win->mark_set_lru); i++)
+		win->mark_set_lru[i].elem_size = sizeof(SelectionRegion);
+
 	mark_init(&win->saved_selections);
 	file->refcount++;
 	win_options_set(win, win->options);

--- a/vis.h
+++ b/vis.h
@@ -960,17 +960,17 @@ VIS_EXPORT void vis_mark_normalize(Array *array);
  * Add selections of focused window to jump list.
  * @param vis The editor instance.
  */
-VIS_EXPORT bool vis_jumplist_save(Vis*);
+VIS_EXPORT void vis_jumplist_save(Vis*);
 /**
  * Navigate jump list backwards.
  * @param vis The editor instance.
  */
-VIS_EXPORT bool vis_jumplist_prev(Vis*);
+VIS_EXPORT void vis_jumplist_prev(Vis*);
 /**
  * Navigate jump list forwards.
  * @param vis The editor instance.
  */
-VIS_EXPORT bool vis_jumplist_next(Vis*);
+VIS_EXPORT void vis_jumplist_next(Vis*);
 /** @} */
 
 /*

--- a/vis.h
+++ b/vis.h
@@ -957,20 +957,16 @@ VIS_EXPORT Array vis_mark_get(Win *win, enum VisMark id);
  */
 VIS_EXPORT void vis_mark_normalize(Array *array);
 /**
- * Add selections of focused window to jump list.
+ * Add selections of focused window to jump list. Equivalent to vis_jumplist(vis, 0).
  * @param vis The editor instance.
  */
-VIS_EXPORT void vis_jumplist_save(Vis*);
+#define vis_jumplist_save(vis) vis_jumplist((vis), 0)
 /**
- * Navigate jump list backwards.
+ * Navigate jump list by a specified amount. Wraps if advance exceeds list size.
  * @param vis The editor instance.
+ * @param advance The amount to advance the cursor by. 0 saves the current selections.
  */
-VIS_EXPORT void vis_jumplist_prev(Vis*);
-/**
- * Navigate jump list forwards.
- * @param vis The editor instance.
- */
-VIS_EXPORT void vis_jumplist_next(Vis*);
+VIS_EXPORT void vis_jumplist(Vis *, int advance);
 /** @} */
 
 /*


### PR DESCRIPTION
Hi!

For those who don't know there is set of cached selections in vis called the jumplist. It can be navigated with `<vis-jumplist-next>` and `<vis-jumplist-prev>`, bound to `g>` and `g<` by default, and saved to with `<vis-jumplist-save>`, bound to `gs` by default. It also gets saved to any time the cursor jumps.

Currently this is completely unusable because the editor mode is not being saved with the selections. The selections will get restored but there is no way to act on them so they just get removed on the next action. This fixes that issue.

Furthermore, from what I could tell the jumplist was supposed to be implemented as a least-recently-used (LRU) cache, obviously with a fixed size. However the code for doing this was vastly over complicated and the size was not enforced at all. I replaced the existing mess with a simple fixed size circular buffer. With this implementation all handling could be trivially collapsed into a single function.

I think this should behave the same as the existing implementation but since I wasn't using it there may be some edge cases I don't know about. I also think the cursor navigation feels a little janky but that part is the same as the existing code. I think its because other parts of the editor save to the jumplist in inappropriate places. Any suggestions there are welcome.