### PR TITLE
Fixed error: implicit declaration of function 'mkdtemp' and 'setenv'

### DIFF
--- a/vis-single.c
+++ b/vis-single.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <sys/wait.h>
 #include <errno.h>
 #include <fcntl.h>


### PR DESCRIPTION
Fixes the following error when running `make docker`:

```shell
#8 10.90 cc -static -Wall -pipe -Wno-initializer-overrides -O2 -ffunction-sections -fdata-sections -fPIE -fstack-protector-all -std=c99 -DNDEBUG -DVERSION=\"3eb7681\"  vis-single.c -static -Wl,-z,now -Wl,-z,relro -lc -Wl,--gc-sections -pie -luntar -llzma -o vis-single
#8 11.09 vis-single.c: In function 'main':
#8 11.09 vis-single.c:110:14: error: implicit declaration of function 'mkdtemp' [-Wimplicit-function-declaration]
#8 11.09   110 |         if (!mkdtemp(tmp_dirname)) {
#8 11.09       |              ^~~~~~~
#8 11.09 vis-single.c:121:13: error: implicit declaration of function 'setenv'; did you mean 'getenv'? [-Wimplicit-function-declaration]
#8 11.09   121 |         if (setenv("PATH", path, 1) == -1 ||
#8 11.09       |             ^~~~~~
#8 11.09       |             getenv
#8 11.11 At top level:
#8 11.11 cc1: note: unrecognized command-line option '-Wno-initializer-overrides' may have been intended to silence earlier diagnostics
#8 11.12 make: *** [Makefile:60: vis-single] Error 1
```