### PR TITLE
support lua 5.5...

### DIFF
--- a/configure
+++ b/configure
@@ -436,7 +436,7 @@ int main(int argc, char *argv[]) {
 }
 EOF
 
-	for liblua in lua lua5.4 lua5.3 lua5.2 lua-5.4 lua-5.3 lua-5.2 lua54 lua53 lua52; do
+	for liblua in lua lua5.5 lua5.4 lua5.3 lua5.2 lua-5.5 lua-5.4 lua-5.3 lua-5.2 lua55 lua54 lua53 lua52; do
 		printf " checking for %s... " "$liblua"
 
 		if test "$have_pkgconfig" = "yes" ; then
@@ -490,7 +490,7 @@ int main(int argc, char *argv[]) {
 }
 EOF
 
-	for liblpeg in lpeg lua5.4-lpeg lua5.3-lpeg lua5.2-lpeg; do
+	for liblpeg in lpeg lua5.5-lpeg lua5.4-lpeg lua5.3-lpeg lua5.2-lpeg; do
 		printf " checking for static %s... " "$liblpeg"
 
 		if test "$have_pkgconfig" = "yes" ; then

--- a/lua/lexers/lexer.lua
+++ b/lua/lexers/lexer.lua
@@ -1091,9 +1091,9 @@ function M.embed(lexer, child, start_rule, end_rule)
 	if child._WORDLISTS then
 		for name, i in pairs(child._WORDLISTS) do
 			if type(name) == 'string' and type(i) == 'number' then
-				name = child._name .. '.' .. name
-				lexer:word_match(name) -- for side effects
-				lexer:set_word_list(name, child._WORDLISTS[i])
+				tname = child._name .. '.' .. name
+				lexer:word_match(tname) -- for side effects
+				lexer:set_word_list(tname, child._WORDLISTS[i])
 			end
 		end
 	end

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -381,7 +381,7 @@ static int newindex_common(lua_State *L) {
 }
 
 static size_t getpos(lua_State *L, int narg) {
-	return lua_tounsigned(L, narg);
+	return (size_t)lua_tointeger(L, narg);
 }
 
 static size_t checkpos(lua_State *L, int narg) {
@@ -399,7 +399,7 @@ static void pushpos(lua_State *L, size_t pos) {
 	if (pos == EPOS)
 		lua_pushnil(L);
 	else
-		lua_pushunsigned(L, pos);
+		lua_pushinteger(L, pos);
 }
 
 static void pushrange(lua_State *L, Filerange *r) {
@@ -409,10 +409,10 @@ static void pushrange(lua_State *L, Filerange *r) {
 	}
 	lua_createtable(L, 0, 2);
 	lua_pushstring(L, "start");
-	lua_pushunsigned(L, r->start);
+	lua_pushinteger(L, r->start);
 	lua_settable(L, -3);
 	lua_pushstring(L, "finish");
-	lua_pushunsigned(L, r->end);
+	lua_pushinteger(L, r->end);
 	lua_settable(L, -3);
 }
 
@@ -701,7 +701,7 @@ err:
 }
 
 static int keymap(lua_State *L, Vis *vis, Win *win) {
-	int mode = luaL_checkint(L, 2);
+	int mode = luaL_checkinteger(L, 2);
 	const char *key = luaL_checkstring(L, 3);
 	const char *help = luaL_optstring(L, 5, NULL);
 	KeyBinding *binding = vis_binding_new(vis);
@@ -807,7 +807,7 @@ static int map(lua_State *L) {
  * @see Window:unmap
  */
 static int keyunmap(lua_State *L, Vis *vis, Win *win) {
-	enum VisMode mode = luaL_checkint(L, 2);
+	enum VisMode mode = luaL_checkinteger(L, 2);
 	const char *key = luaL_checkstring(L, 3);
 	bool ret;
 	if (!win)
@@ -853,7 +853,7 @@ static bool binding_collect(const char *key, void *value, void *ctx) {
 static int mappings(lua_State *L) {
 	Vis *vis = obj_ref_check(L, 1, "vis");
 	lua_newtable(L);
-	for (Mode *mode = mode_get(vis, luaL_checkint(L, 2)); mode; mode = mode->parent) {
+	for (Mode *mode = mode_get(vis, luaL_checkinteger(L, 2)); mode; mode = mode->parent) {
 		if (!mode->bindings)
 			continue;
 		map_iterate(mode->bindings, binding_collect, vis->lua);
@@ -871,7 +871,7 @@ static int mappings(lua_State *L) {
  */
 static int motion(lua_State *L) {
 	Vis *vis = obj_ref_check(L, 1, "vis");
-	enum VisMotion id = luaL_checkunsigned(L, 2);
+	enum VisMotion id = luaL_checkinteger(L, 2);
 	// TODO handle var args?
 	lua_pushboolean(L, vis && vis_motion(vis, id));
 	return 1;
@@ -882,7 +882,7 @@ static size_t motion_lua(Vis *vis, Win *win, void *data, size_t pos) {
 	if (!L || !func_ref_get(L, data) || !obj_ref_new(L, win, VIS_LUA_TYPE_WINDOW))
 		return EPOS;
 
-	lua_pushunsigned(L, pos);
+	lua_pushinteger(L, pos);
 	if (pcall(vis, L, 2, 1) != 0)
 		return EPOS;
 	return getpos(L, -1);
@@ -920,7 +920,7 @@ static int motion_register(lua_State *L) {
  */
 static int operator(lua_State *L) {
 	Vis *vis = obj_ref_check(L, 1, "vis");
-	enum VisOperator id = luaL_checkunsigned(L, 2);
+	enum VisOperator id = luaL_checkinteger(L, 2);
 	// TODO handle var args?
 	lua_pushboolean(L, vis && vis_operator(vis, id));
 	return 1;
@@ -979,7 +979,7 @@ static int operator_register(lua_State *L) {
  */
 static int textobject(lua_State *L) {
 	Vis *vis = obj_ref_check(L, 1, "vis");
-	enum VisTextObject id = luaL_checkunsigned(L, 2);
+	enum VisTextObject id = luaL_checkinteger(L, 2);
 	lua_pushboolean(L, vis_textobject(vis, id));
 	return 1;
 }
@@ -988,7 +988,7 @@ static Filerange textobject_lua(Vis *vis, Win *win, void *data, size_t pos) {
 	lua_State *L = vis->lua;
 	if (!L || !func_ref_get(L, data) || !obj_ref_new(L, win, VIS_LUA_TYPE_WINDOW))
 		return text_range_empty();
-	lua_pushunsigned(L, pos);
+	lua_pushinteger(L, pos);
 	if (pcall(vis, L, 2, 2) != 0 || lua_isnil(L, -1))
 		return text_range_empty();
 	return text_range_new(getpos(L, -2), getpos(L, -1));
@@ -1090,7 +1090,7 @@ static bool command_lua(Vis *vis, Win *win, void *data, bool force, const char *
 		return false;
 	lua_newtable(L);
 	for (size_t i = 0; argv[i]; i++) {
-		lua_pushunsigned(L, i);
+		lua_pushinteger(L, i);
 		lua_pushstring(L, argv[i]);
 		lua_settable(L, -3);
 	}
@@ -1238,7 +1238,7 @@ static int replace(lua_State *L) {
  */
 static int exit_func(lua_State *L) {
 	Vis *vis = obj_ref_check(L, 1, "vis");
-	int code = luaL_checkint(L, 2);
+	int code = luaL_checkinteger(L, 2);
 	vis_exit(vis, code);
 	return 0;
 }
@@ -1421,7 +1421,7 @@ static int vis_index(lua_State *L) {
 		}
 
 		if (strcmp(key, "mode") == 0) {
-			lua_pushunsigned(L, vis->mode->id);
+			lua_pushinteger(L, vis->mode->id);
 			return 1;
 		}
 
@@ -1440,7 +1440,7 @@ static int vis_index(lua_State *L) {
 			if (count == VIS_COUNT_UNKNOWN)
 				lua_pushnil(L);
 			else
-				lua_pushunsigned(L, count);
+				lua_pushinteger(L, count);
 			return 1;
 		}
 
@@ -1481,7 +1481,7 @@ static int vis_options_assign(Vis *vis, lua_State *L, const char *key, int next)
 	} else if (strcmp(key, "changecolors") == 0) {
 		vis->change_colors = lua_toboolean(L, next);
 	} else if (strcmp(key, "escdelay") == 0) {
-		termkey_set_waittime(vis->ui.termkey, luaL_checkint(L, next));
+		termkey_set_waittime(vis->ui.termkey, luaL_checkinteger(L, next));
 	} else if (strcmp(key, "ignorecase") == 0 || strcmp(key, "ic") == 0) {
 		vis->ignorecase = lua_toboolean(L, next);
 	} else if (strcmp(key, "loadmethod") == 0) {
@@ -1507,7 +1507,7 @@ static int vis_newindex(lua_State *L) {
 	if (lua_isstring(L, 2)) {
 		const char *key = lua_tostring(L, 2);
 		if (strcmp(key, "mode") == 0) {
-			enum VisMode mode = luaL_checkunsigned(L, 3);
+			enum VisMode mode = luaL_checkinteger(L, 3);
 			vis_mode_switch(vis, mode);
 			return 0;
 		}
@@ -1517,7 +1517,7 @@ static int vis_newindex(lua_State *L) {
 			if (lua_isnil(L, 3))
 				count = VIS_COUNT_UNKNOWN;
 			else
-				count = luaL_checkunsigned(L, 3);
+				count = luaL_checkinteger(L, 3);
 			vis->action.count = count;
 			return 0;
 		}
@@ -1622,7 +1622,7 @@ static int vis_options_index(lua_State *L) {
 			lua_pushboolean(L, vis->change_colors);
 			return 1;
 		} else if (strcmp(key, "escdelay") == 0) {
-			lua_pushunsigned(L, termkey_get_waittime(vis->ui.termkey));
+			lua_pushinteger(L, termkey_get_waittime(vis->ui.termkey));
 			return 1;
 		} else if (strcmp(key, "ignorecase") == 0 || strcmp(key, "ic") == 0) {
 			lua_pushboolean(L, vis->ignorecase);
@@ -1684,7 +1684,7 @@ static int ui_index(lua_State *L) {
 		const char *key  = lua_tostring(L, 2);
 
 		if (strcmp(key, "layout") == 0) {
-			lua_pushunsigned(L, ui->layout);
+			lua_pushinteger(L, ui->layout);
 			return 1;
 		}
 	}
@@ -1699,7 +1699,7 @@ static int ui_newindex(lua_State *L) {
 		const char *key  = lua_tostring(L, 2);
 
 		if (strcmp(key, "layout") == 0) {
-			ui_arrange(ui, luaL_checkint(L, 3));
+			ui_arrange(ui, luaL_checkinteger(L, 3));
 			return 0;
 		}
 	}
@@ -1724,7 +1724,7 @@ static int registers_index(lua_State *L) {
 	Array data = vis_register_get(vis, reg);
 	for (size_t i = 0, len = data.len; i < len; i++) {
 		TextString *string = array_get(&data, i);
-		lua_pushunsigned(L, i+1);
+		lua_pushinteger(L, i+1);
 		lua_pushlstring(L, string->data, string->len);
 		lua_settable(L, -3);
 	}
@@ -1758,7 +1758,7 @@ static int registers_newindex(lua_State *L) {
 
 static int registers_len(lua_State *L) {
 	Vis *vis = lua_touserdata(L, lua_upvalueindex(1));
-	lua_pushunsigned(L, LENGTH(vis->registers));
+	lua_pushinteger(L, LENGTH(vis->registers));
 	return 1;
 }
 
@@ -1832,21 +1832,21 @@ static int window_index(lua_State *L) {
 			pushrange(L, &l);
 			lua_settable(L, -3);
 			lua_pushstring(L, "width");
-			lua_pushunsigned(L, win->view.width);
+			lua_pushinteger(L, win->view.width);
 			lua_settable(L, -3);
 			lua_pushstring(L, "height");
-			lua_pushunsigned(L, win->view.height);
+			lua_pushinteger(L, win->view.height);
 			lua_settable(L, -3);
 			return 1;
 		}
 
 		if (strcmp(key, "width") == 0) {
-			lua_pushunsigned(L, win->width);
+			lua_pushinteger(L, win->width);
 			return 1;
 		}
 
 		if (strcmp(key, "height") == 0) {
-			lua_pushunsigned(L, win->height);
+			lua_pushinteger(L, win->height);
 			return 1;
 		}
 
@@ -1885,7 +1885,7 @@ static int window_options_assign(Win *win, lua_State *L, const char *key, int ne
 		if (lua_isstring(L, next))
 			view_breakat_set(&win->view, lua_tostring(L, next));
 	} else if (strcmp(key, "colorcolumn") == 0 || strcmp(key, "cc") == 0) {
-		win->view.colorcolumn = luaL_checkunsigned(L, next);
+		win->view.colorcolumn = luaL_checkinteger(L, next);
 	} else if (strcmp(key, "cursorline") == 0 || strcmp(key, "cul") == 0) {
 		if (lua_toboolean(L, next))
 			flags |= UI_OPTION_CURSOR_LINE;
@@ -1935,9 +1935,9 @@ static int window_options_assign(Win *win, lua_State *L, const char *key, int ne
 			flags &= ~UI_OPTION_STATUSBAR;
 		win_options_set(win, flags);
 	} else if (strcmp(key, "wrapcolumn") == 0 || strcmp(key, "wc") == 0) {
-		win->view.wrapcolumn = luaL_checkunsigned(L, next);
+		win->view.wrapcolumn = luaL_checkinteger(L, next);
 	} else if (strcmp(key, "tabwidth") == 0 || strcmp(key, "tw") == 0) {
-		view_tabwidth_set(&win->view, luaL_checkint(L, next));
+		view_tabwidth_set(&win->view, luaL_checkinteger(L, next));
 	} else if (strcmp(key, "expandtab") == 0 || strcmp(key, "et") == 0) {
 		win->expandtab = lua_toboolean(L, next);
 	}
@@ -2039,7 +2039,7 @@ static int window_unmap(lua_State *L) {
  */
 static int window_style_define(lua_State *L) {
 	Win *win = obj_ref_check(L, 1, VIS_LUA_TYPE_WINDOW);
-	enum UiStyle id = luaL_checkunsigned(L, 2);
+	enum UiStyle id = luaL_checkinteger(L, 2);
 	const char *style = luaL_checkstring(L, 3);
 	bool ret = ui_style_define(win, id, style);
 	lua_pushboolean(L, ret);
@@ -2061,7 +2061,7 @@ static int window_style_define(lua_State *L) {
  */
 static int window_style(lua_State *L) {
 	Win *win = obj_ref_check(L, 1, VIS_LUA_TYPE_WINDOW);
-	enum UiStyle style = luaL_checkunsigned(L, 2);
+	enum UiStyle style = luaL_checkinteger(L, 2);
 	size_t start = checkpos(L, 3);
 	size_t end = checkpos(L, 4);
 	bool keep_non_default = lua_isboolean(L, 5) && lua_toboolean(L, 5);
@@ -2088,7 +2088,7 @@ static int window_style(lua_State *L) {
  */
 static int window_style_pos(lua_State *L) {
 	Win *win = obj_ref_check(L, 1, VIS_LUA_TYPE_WINDOW);
-	enum UiStyle style = luaL_checkunsigned(L, 2);
+	enum UiStyle style = luaL_checkinteger(L, 2);
 	size_t x = checkpos(L, 3);
 	size_t y = checkpos(L, 4);
 	bool keep_non_default = lua_isboolean(L, 5) && lua_toboolean(L, 5);
@@ -2202,7 +2202,7 @@ static int window_options_index(lua_State *L) {
 			lua_pushstring(L, win->view.breakat);
 			return 1;
 		} else if (strcmp(key, "colorcolumn") == 0 || strcmp(key, "cc") == 0) {
-			lua_pushunsigned(L, win->view.colorcolumn);
+			lua_pushinteger(L, win->view.colorcolumn);
 			return 1;
 		} else if (strcmp(key, "cursorline") == 0 || strcmp(key, "cul") == 0) {
 			lua_pushboolean(L, win->options & UI_OPTION_CURSOR_LINE);
@@ -2235,7 +2235,7 @@ static int window_options_index(lua_State *L) {
 			lua_pushinteger(L, win->view.tabwidth);
 			return 1;
 		} else if (strcmp(key, "wrapcolumn") == 0 || strcmp(key, "wc") == 0) {
-			lua_pushunsigned(L, win->view.wrapcolumn);
+			lua_pushinteger(L, win->view.wrapcolumn);
 			return 1;
 		}
 	}
@@ -2259,7 +2259,7 @@ static const struct luaL_Reg window_option_funcs[] = {
 
 static int window_selections_index(lua_State *L) {
 	View *view = obj_ref_check(L, 1, VIS_LUA_TYPE_SELECTIONS);
-	size_t index = luaL_checkunsigned(L, 2);
+	size_t index = luaL_checkinteger(L, 2);
 	size_t count = view->selection_count;
 	if (index == 0 || index > count)
 		goto err;
@@ -2276,7 +2276,7 @@ err:
 
 static int window_selections_len(lua_State *L) {
 	View *view = obj_ref_check(L, 1, VIS_LUA_TYPE_SELECTIONS);
-	lua_pushunsigned(L, view->selection_count);
+	lua_pushinteger(L, view->selection_count);
 	return 1;
 }
 
@@ -2399,17 +2399,17 @@ static int window_selection_index(lua_State *L) {
 		}
 
 		if (strcmp(key, "line") == 0) {
-			lua_pushunsigned(L, view_cursors_line(sel));
+			lua_pushinteger(L, view_cursors_line(sel));
 			return 1;
 		}
 
 		if (strcmp(key, "col") == 0) {
-			lua_pushunsigned(L, view_cursors_col(sel));
+			lua_pushinteger(L, view_cursors_col(sel));
 			return 1;
 		}
 
 		if (strcmp(key, "number") == 0) {
-			lua_pushunsigned(L, view_selections_number(sel)+1);
+			lua_pushinteger(L, view_selections_number(sel)+1);
 			return 1;
 		}
 
@@ -2558,7 +2558,7 @@ static int file_index(lua_State *L) {
 		}
 
 		if (strcmp(key, "size") == 0) {
-			lua_pushunsigned(L, text_size(file->text));
+			lua_pushinteger(L, text_size(file->text));
 			return 1;
 		}
 
@@ -2569,7 +2569,7 @@ static int file_index(lua_State *L) {
 
 		if (strcmp(key, "permission") == 0) {
 			struct stat stat = text_stat(file->text);
-			lua_pushunsigned(L, stat.st_mode & 0777);
+			lua_pushinteger(L, stat.st_mode & 0777);
 			return 1;
 		}
 
@@ -2691,7 +2691,7 @@ static int file_snapshot(lua_State *L) {
 static int file_lines_iterator_it(lua_State *L);
 static int file_lines_iterator(lua_State *L) {
 	File *file = obj_ref_check(L, 1, VIS_LUA_TYPE_FILE);
-	size_t line = luaL_optunsigned(L, 2, 1);
+	size_t line = luaL_optinteger(L, 2, 1);
 	size_t *pos = lua_newuserdata(L, sizeof *pos);
 	*pos = text_pos_by_lineno(file->text, line);
 	lua_pushcclosure(L, file_lines_iterator_it, 2);
@@ -2780,7 +2780,7 @@ static int file_mark_get(lua_State *L) {
 	if (pos == EPOS)
 		lua_pushnil(L);
 	else
-		lua_pushunsigned(L, pos);
+		lua_pushinteger(L, pos);
 	return 1;
 }
 
@@ -2829,7 +2829,7 @@ static const struct luaL_Reg file_funcs[] = {
 
 static int file_lines_index(lua_State *L) {
 	Text *txt = obj_ref_check(L, 1, VIS_LUA_TYPE_TEXT);
-	size_t line = luaL_checkunsigned(L, 2);
+	size_t line = luaL_checkinteger(L, 2);
 	size_t start = text_pos_by_lineno(txt, line);
 	size_t end = text_line_end(txt, start);
 	if (start != EPOS && end != EPOS) {
@@ -2848,7 +2848,7 @@ err:
 
 static int file_lines_newindex(lua_State *L) {
 	Text *txt = obj_ref_check(L, 1, VIS_LUA_TYPE_TEXT);
-	size_t line = luaL_checkunsigned(L, 2);
+	size_t line = luaL_checkinteger(L, 2);
 	size_t size;
 	const char *data = luaL_checklstring(L, 3, &size);
 	if (line == 0) {
@@ -2876,7 +2876,7 @@ static int file_lines_len(lua_State *L) {
 		lines = text_lineno_by_pos(txt, size);
 	if (lines > 1 && text_byte_get(txt, size-1, &lastchar) && lastchar == '\n')
 		lines--;
-	lua_pushunsigned(L, lines);
+	lua_pushinteger(L, lines);
 	return 1;
 }
 
@@ -2903,7 +2903,7 @@ static int window_marks_index(lua_State *L) {
 	Array arr = vis_mark_get(win, mark);
 	for (size_t i = 0, len = arr.len; i < len; i++) {
 		Filerange *range = array_get(&arr, i);
-		lua_pushunsigned(L, i+1);
+		lua_pushinteger(L, i+1);
 		pushrange(L, range);
 		lua_settable(L, -3);
 	}
@@ -2942,7 +2942,7 @@ static int window_marks_newindex(lua_State *L) {
 }
 
 static int window_marks_len(lua_State *L) {
-	lua_pushunsigned(L, VIS_MARK_INVALID);
+	lua_pushinteger(L, VIS_MARK_INVALID);
 	return 1;
 }
 
@@ -3177,7 +3177,12 @@ static void *alloc_lua(void *ud, void *ptr, size_t osize, size_t nsize) {
  * @function init
  */
 static void vis_lua_init(Vis *vis) {
-	lua_State *L = lua_newstate(alloc_lua, vis);
+	lua_State *L =
+#if LUA_VERSION_NUM >= 505
+		lua_newstate(alloc_lua, vis, luaL_makeseed(NULL));
+#else
+		lua_newstate(alloc_lua, vis);
+#endif
 	if (!L)
 		return;
 	vis->lua = L;
@@ -3277,7 +3282,7 @@ static void vis_lua_init(Vis *vis) {
 	};
 
 	for (size_t i = 0; i < LENGTH(textobjects); i++) {
-		lua_pushunsigned(L, textobjects[i].id);
+		lua_pushinteger(L, textobjects[i].id);
 		lua_pushcclosure(L, file_text_object, 1);
 		lua_setfield(L, -2, textobjects[i].name);
 	}
@@ -3311,7 +3316,7 @@ static void vis_lua_init(Vis *vis) {
 	};
 
 	for (size_t i = 0; i < LENGTH(styles); i++) {
-		lua_pushunsigned(L, styles[i].id);
+		lua_pushinteger(L, styles[i].id);
 		lua_setfield(L, -2, styles[i].name);
 	}
 
@@ -3330,7 +3335,7 @@ static void vis_lua_init(Vis *vis) {
 
 	obj_type_new(L, VIS_LUA_TYPE_UI);
 	luaL_setfuncs(L, ui_funcs, 0);
-	lua_pushunsigned(L, ui_terminal_colors());
+	lua_pushinteger(L, ui_terminal_colors());
 	lua_setfield(L, -2, "colors");
 	lua_newtable(L);
 	static const struct {
@@ -3341,7 +3346,7 @@ static void vis_lua_init(Vis *vis) {
 		{ UI_LAYOUT_VERTICAL, "VERTICAL" },
 	};
 	for (size_t i = 0; i <  LENGTH(layouts); i++) {
-		lua_pushunsigned(L, layouts[i].id);
+		lua_pushinteger(L, layouts[i].id);
 		lua_setfield(L, -2, layouts[i].name);
 	}
 	lua_setfield(L, -2, "layouts");
@@ -3371,7 +3376,7 @@ static void vis_lua_init(Vis *vis) {
 		{ VIS_MODE_REPLACE,          "REPLACE"          },
 	};
 	for (size_t i = 0; i < LENGTH(modes); i++) {
-		lua_pushunsigned(L, modes[i].id);
+		lua_pushinteger(L, modes[i].id);
 		lua_setfield(L, -2, modes[i].name);
 	}
 	lua_setfield(L, -2, "modes");


### PR DESCRIPTION
... and replace the functions for unsigned integers with their signed equivalents, using a type cast where needed.

Actually the functions for unsigned integers were deprecated since lua 5.3...

https://www.lua.org/manual/5.3/manual.html#8.3

Also lua_newstate() requires a third argument since 5.5...

https://www.lua.org/manual/5.5/manual.html#8.3

Finally the key in a for loop is now const, so use a temporary variable instead.