### PR TITLE
configure: fall back to brew for lpeg detection on macOS

### DIFF
--- a/configure
+++ b/configure
@@ -529,6 +529,27 @@ EOF
 		fi
 	done
 
+	# Homebrew on macOS does not provide a pkg-config file or a static
+	# liblpeg.a in the default linker search path. Try to locate it
+	# via brew --prefix as a fallback.
+	if test -z "${CFLAGS_LPEG}" && cmdexists brew ; then
+		lpeg_prefix=$(brew --prefix lpeg 2>/dev/null)
+		if test -n "$lpeg_prefix" -a -d "$lpeg_prefix/lib" ; then
+			printf " checking for lpeg via brew... "
+			CFLAGS_LPEG=""
+			LDFLAGS_LPEG="-L${lpeg_prefix}/lib -llpeg"
+			if $CC $CFLAGS $CFLAGS_LUA $CFLAGS_LPEG "$tmpc" \
+				$LDFLAGS $LDFLAGS_LUA $LDFLAGS_LPEG -o "$tmpo" >/dev/null 2>&1 ; then
+				CFLAGS_LPEG="-DCONFIG_LPEG=1"
+				printf "yes\n"
+			else
+				printf "no\n"
+				CFLAGS_LPEG=""
+				LDFLAGS_LPEG=""
+			fi
+		fi
+	fi
+
 	test "$lpeg" = "yes" -a -z "${CFLAGS_LPEG}" && fail "$0: cannot find liblpeg"
 fi
 


### PR DESCRIPTION
## Summary

On macOS with Homebrew, `./configure` fails to detect lpeg for static linking because Homebrew's lpeg package does not ship a `pkg-config` file or install `liblpeg` into the default linker search path.

This adds a fallback that uses `brew --prefix lpeg` to locate the library when the existing pkg-config and `-l` flag detection methods both fail.

## Problem

Running `./configure && make && sudo make install` on macOS with Homebrew-installed lpeg results in vis being built without lpeg support. At runtime, `require('lpeg')` fails because Lua's `package.cpath` doesn't include the Homebrew Cellar path (especially after a Lua version upgrade, e.g. 5.4 -> 5.5), and syntax highlighting is broken:

```
/usr/local/share/vis/lexers/lexer.lua:862: module 'lpeg' not found
```

The root cause is that the configure script only tries:
1. `pkg-config` with names: `lpeg`, `lua5.5-lpeg`, etc. — Homebrew has no `.pc` file for lpeg
2. Bare `-llpeg` — Homebrew installs `liblpeg.dylib` under its Cellar, not in `/opt/homebrew/lib/`

## Fix

After the existing detection loop, if lpeg was not found and `brew` is available, try `brew --prefix lpeg` to get the library path and link against it. This is consistent with how Homebrew packages are designed to be discovered. The fallback only runs when the existing methods fail, so it has no effect on Linux or non-Homebrew systems.

## Testing

Verified with Homebrew's lpeg unlinked (simulating fresh install state):
- `./configure` — auto mode finds lpeg via brew fallback
- `./configure --enable-lpeg-static` — explicit mode finds lpeg via brew fallback
- `./configure --disable-lpeg-static` — correctly skips lpeg entirely
- `make` succeeds with `CONFIG_LPEG=1`