### PR TITLE
number-inc-dec: fix wrong increment in a word

### DIFF
--- a/lua/plugins/number-inc-dec.lua
+++ b/lua/plugins/number-inc-dec.lua
@@ -18,17 +18,29 @@ local change = function(delta)
 	for selection in win:selections_iterator() do
 		local pos = selection.pos
 		if not pos then goto continue end
-		local word = file:text_object_word(pos);
-		if not word then goto continue end
-		local data = file:content(word.start, 1024)
+		local data = file:content(pos, 1024)
 		if not data then goto continue end
 		local s, e = pattern:match(data)
 		if not s then goto continue end
+		if s == 1 then
+			-- detect if the cursor is in the middle of a number
+			local word = file:text_object_word(pos)
+			-- the cursor is in the middle of a word
+			if word.start < pos then
+				local word_prefix = pos-word.start
+				data = file:content(word.start, word_prefix)..data
+				local e_old = e + word_prefix - 1
+				pos = pos - word_prefix
+				while e_old > e do
+					s, e = pattern:match(data, e)
+				end
+			end
+		end
 		data = string.sub(data, s, e-1)
 		if #data == 0 then goto continue end
 		-- align start and end for fileindex
-		s = word.start + s - 1
-		e = word.start + e - 1
+		s = pos + s - 1
+		e = pos + e - 1
 		local base, format, padding = 10, 'd', 0
 		if lexer.oct_num:match(data) then
 			base = 8

--- a/test/lua/number-inc.in
+++ b/test/lua/number-inc.in
@@ -1,0 +1,3 @@
+1.2rc3
+1xx19xx
+1foo22bar3

--- a/test/lua/number-inc.lua
+++ b/test/lua/number-inc.lua
@@ -1,0 +1,26 @@
+require("plugins/number-inc-dec")
+local win = vis.win
+
+describe("between numbers", function()
+	it("between numbers", function()
+		win.selection.pos = 4
+		vis:feedkeys("<C-a>")
+		assert.are.equal("1.2rc4", win.file.lines[1])
+	end)
+end)
+
+describe("in number", function()
+	it("in number", function()
+		win.selection.pos = 11
+		vis:feedkeys("<C-a>")
+		assert.are.equal("1xx20xx", win.file.lines[2])
+	end)
+end)
+
+describe("end of word/file", function()
+	it("end of word/file", function()
+		win.selection.pos = 24
+		vis:feedkeys("<C-a>")
+		assert.are.equal("1foo22bar4", win.file.lines[3])
+	end)
+end)


### PR DESCRIPTION
Only the number under the cursor or the next number after the cursor should be changed.
However, if we unconditionally use the text object to detect were the number to increment is, words like `1rc3` could result in the number to the left of the curser to be changed.

This is fixed by only looking at the word under the cursor if the cursor is actually on a number.

Fixes #1324.