### PR TITLE
number-inc-dec: fix not changing the whole number

### DIFF
--- a/lua/plugins/number-inc-dec.lua
+++ b/lua/plugins/number-inc-dec.lua
@@ -29,8 +29,9 @@ local change = function(delta)
 			if word.start < pos then
 				local word_prefix = pos-word.start
 				data = file:content(word.start, word_prefix)..data
-				s = s + word_prefix
-				local e_old = e + word_prefix
+				s = s + word_prefix -- make the start relative to the word's start
+				local e_old = e + word_prefix -- remember the old end relative to the word' start
+				e = 1 -- reset the end mark to search the word until we find the complete number
 				pos = pos - word_prefix
 				while e_old > e do
 					s, e = pattern:match(data, e)

--- a/test/lua/number-inc.in
+++ b/test/lua/number-inc.in
@@ -2,3 +2,4 @@
 1xx19xx
 1foo22bar3
 11y
+19

--- a/test/lua/number-inc.lua
+++ b/test/lua/number-inc.lua
@@ -10,31 +10,45 @@ describe("between numbers", function()
 end)
 
 describe("in number", function()
-	it("in number", function()
+	it("enclosed number", function()
 		win.selection.pos = 11
 		vis:feedkeys("<C-a>")
 		assert.are.equal("1xx20xx", win.file.lines[2])
 	end)
-end)
 
-describe("end of word/file", function()
-	it("end of word/file", function()
+	it("enclosed number", function()
+		win.selection.pos = 10
+		vis:feedkeys("<C-a>")
+		assert.are.equal("1xx21xx", win.file.lines[2])
+	end)
+
+	it("end of word", function()
 		win.selection.pos = 24
 		vis:feedkeys("<C-a>")
 		assert.are.equal("1foo22bar4", win.file.lines[3])
 	end)
-end)
 
-describe("position in number", function()
-	it("first digit", function()
+	it("first digit word start", function()
 		win.selection.pos = 26
 		vis:feedkeys("<C-a>")
 		assert.are.equal("12y", win.file.lines[4])
 	end)
 
-	it("last digit", function()
+	it("last digit word start", function()
 		win.selection.pos = 27
 		vis:feedkeys("<C-a>")
 		assert.are.equal("13y", win.file.lines[4])
+	end)
+
+	it("first digit single number", function()
+		win.selection.pos = 30
+		vis:feedkeys("<C-a>")
+		assert.are.equal("20", win.file.lines[5])
+	end)
+
+	it("last digit single number", function()
+		win.selection.pos = 31
+		vis:feedkeys("<C-x>")
+		assert.are.equal("19", win.file.lines[5])
 	end)
 end)


### PR DESCRIPTION
Reset the end marker in order to rescan the word to find the complete number relative to the word's start.

Fixes: da84fe700880eb988ea0819f9c823547287f28a9
Fixes: 13c577a1b3802562dc43235a5a4a8e5acdd331a9

Follow up to: #1326 