### PR TITLE
[RFC] Add a plugin namespace

### DIFF
--- a/lua/plugins/complete-word.lua
+++ b/lua/plugins/complete-word.lua
@@ -1,5 +1,14 @@
 -- complete word at primary selection location using vis-complete(1)
 
+-- Table of hooks other plugins may register to insert their completion
+-- candidates.
+-- Hooks are called with the current word prefix and MUST return a table
+-- containing their completion candidates.
+local candidate_hooks = {}
+if vis.plugins then
+	vis.plugins["complete-word"] = {candidate_hooks = candidate_hooks}
+end
+
 vis:map(vis.modes.INSERT, "<C-n>", function()
 	local win = vis.win
 	local file = win.file
@@ -17,6 +26,13 @@ vis:map(vis.modes.INSERT, "<C-n>", function()
 	-- collect words starting with prefix
 	vis:command("x/\\b" .. prefix .. "\\w+/")
 	local candidates = {}
+
+	for _, candidate_hook in ipairs(candidate_hooks) do
+		for _, candidate in ipairs(candidate_hook(prefix)) do
+		  table.insert(candidates, candidate)
+		end
+	end
+
 	for sel in win:selections_iterator() do
 		table.insert(candidates, file:content(sel.range))
 	end

--- a/lua/vis-std.lua
+++ b/lua/vis-std.lua
@@ -89,6 +89,11 @@ local modes = {
 	[vis.modes.REPLACE] = 'REPLACE',
 }
 
+-- Namespace for lua plugins to expose their API and communicate with each other.
+-- Each plugin can use its own namespace vis.plugins['plugin-name'].
+local plugins = {}
+vis.plugins = plugins
+
 vis.events.subscribe(vis.events.WIN_STATUS, function(win)
 	local left_parts = {}
 	local right_parts = {}


### PR DESCRIPTION
Multiple times we needed a way for plugins to communicate with each other.
Currently the user has to do the plumbing in their `visrc.lua` file.

This proposal simply adds a global table `vis.plugins` as central namespace
for all plugins to expose their APIs.

Each plugin would insert its own table `vis.plugins['plugin-name']`.

This allows plugins to be easily extended by other plugins without
duplicating a lot of user configuration code.

### Usecases:

* The status line could be extendable
* The word-completion could be extended
* The lspc configuration could be changed by an editorconf plugin
* ...

### Questions

* Do we want this in general?
    * In my opinion it is really simple but powerful, therefore a good addition.
* Should the plugin namespace be userdata exposed by C to prevent it from be deleted `vis.plugins=nil`?
* Should the table be read-only and use registration functions to add new plugin subtables? 

### Related

* https://github.com/martanne/vis/issues/1332
* https://github.com/martanne/vis/issues/1311
* https://gitlab.com/muhq/vis-lspc/-/merge_requests/54

Fixes #1332.
