### PR TITLE
fix: unsafe c buffer function used without size chec... in vis-lua.c...

### DIFF
--- a/vis-lua.c
+++ b/vis-lua.c
@@ -3104,7 +3104,7 @@ static bool vis_lua_path_strip(Vis *vis) {
 				*next++ = '\0';
 			if (strstr(elem, "./"))
 				continue; /* skip relative path entries */
-			stripped_elem += sprintf(stripped_elem, "%s;", elem);
+			stripped_elem += snprintf(stripped_elem, strlen(path)+2-(size_t)(stripped_elem-stripped), "%s;", elem);
 		}
 
 		lua_pushstring(L, stripped);


### PR DESCRIPTION
## Summary
Fix high severity security issue in `vis-lua.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | utils.custom.buffer-overflow-strcpy |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `utils.custom.buffer-overflow-strcpy` |
| **File** | `vis-lua.c:3107` |

**Description**: Unsafe C buffer function used without size checking. This can lead to buffer overflow vulnerabilities. Use size-bounded alternatives like strncpy(), strncat(), snprintf(), or fgets().


## Changes
- `vis-lua.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
