### PR TITLE
fix: two unbounded strcpy() calls exist in the codebase in ui-terminal.c

### DIFF
--- a/ui-terminal.c
+++ b/ui-terminal.c
@@ -192,7 +192,7 @@ static void ui_draw_string(Ui *tui, int x, int y, const char *str, int win_id, e
 		if (!len)
 			break;
 		len = MIN(len, cell_size);
-		strncpy(cells[x].data, str, len);
+		memcpy(cells[x].data, str, len);
 		cells[x].data[len] = '\0';
 		cells[x].style = default_style;
 		ui_window_style_set(tui, win_id, cells + x++, style_id, false);
@@ -318,7 +318,7 @@ void ui_arrange(Ui *tui, enum UiLayout layout) {
 			if (n) {
 				Cell *cells = tui->cells;
 				for (int i = 0; i < max_height; i++) {
-					strcpy(cells[x].data,"│");
+					snprintf(cells[x].data, sizeof(cells[x].data), "%s", "│");
 					cells[x].style = tui->styles[UI_STYLE_SEPARATOR];
 					cells += tui->width;
 				}

--- a/view.c
+++ b/view.c
@@ -73,7 +73,7 @@ void window_status_update(Vis *vis, Win *win) {
 	const char *mode = vis->mode->status;
 
 	if (focused && mode)
-		strcpy(left_parts[left_count++], mode);
+		snprintf(left_parts[left_count++], sizeof(left_parts[0]), "%s", mode);
 
 	snprintf(left_parts[left_count++], sizeof(left_parts[0]), "%s%s%s",
 	         filename ? filename : "[No Name]",


### PR DESCRIPTION
## Summary
Fix high severity security issue in `ui-terminal.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `ui-terminal.c:321` |

**Description**: Two unbounded strcpy() calls exist in the codebase. In ui-terminal.c:321, a Unicode box-drawing character is copied into cells[x].data without verifying the destination buffer size. In view.c:76, the mode string (which can be influenced by Lua plugins or editor configuration) is copied into a fixed-size left_parts array element without bounds checking. If the source string exceeds the destination buffer, adjacent stack or heap memory is overwritten, enabling memory corruption.

## Changes
- `ui-terminal.c`
- `view.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
