### PR TITLE
ui: implement numberwidth option

### DIFF
--- a/man/vis.1
+++ b/man/vis.1
@@ -1,4 +1,4 @@
-.Dd January 14, 2017
+.Dd May 14, 2026
 .Dt VIS 1
 .Os Vis VERSION
 .
@@ -1369,6 +1369,12 @@ Display absolute line numbers.
 .
 .It Ic relativenumbers , Ic rnu Op Cm off
 Display relative line numbers.
+.
+.It Ic numberwidth , Ic nuw Op Cm 0
+Minimum sidebar width when sidebar is enabled with
+.Ic number
+or
+.Ic relativenumbers .
 .
 .It Ic cursorline , Ic cul Op Cm off
 Highlight line primary cursor resides on.

--- a/ui-terminal.c
+++ b/ui-terminal.c
@@ -199,6 +199,23 @@ static void ui_draw_string(Ui *tui, int x, int y, const char *str, int win_id, e
 	}
 }
 
+VIS_INTERNAL uint8_t
+u32_count_digits(uint32_t a)
+{
+	// NOTE(rnp): guaranteed branchless, fixed cost regardless of input
+	uint8_t result = (a >= 1000000000) +
+	                 (a >= 100000000)  +
+	                 (a >= 10000000)   +
+	                 (a >= 1000000)    +
+	                 (a >= 100000)     +
+	                 (a >= 10000)      +
+	                 (a >= 1000)       +
+	                 (a >= 100)        +
+	                 (a >= 10)         +
+	                 1;
+	return result;
+}
+
 static void ui_window_draw(Win *win) {
 	Ui *ui = &win->vis->ui;
 	View *view = &win->view;
@@ -210,7 +227,12 @@ static void ui_window_draw(Win *win) {
 	bool sidebar = nu || rnu;
 
 	int width = win->width, height = win->height;
-	int sidebar_width = sidebar ? snprintf(NULL, 0, "%zd ", line->lineno + height - 2) : 0;
+
+	int sidebar_width = 0;
+	if (sidebar) {
+		sidebar_width = u32_count_digits(line->lineno + height - 2) + 1;
+		sidebar_width = MAX(sidebar_width, win->min_sidebar_width);
+	}
 	if (sidebar_width != win->sidebar_width) {
 		view_resize(view, width - sidebar_width, status ? height - 1 : height);
 		win->sidebar_width = sidebar_width;

--- a/vis-core.h
+++ b/vis-core.h
@@ -156,6 +156,7 @@ struct Win {
 	int width, height;      /* window dimension including status bar */
 	int x, y;               /* window position */
 	int sidebar_width;      /* width of the sidebar showing line numbers etc. */
+	int min_sidebar_width;  /* user specified minimum sidebar width */
 	enum UiOption options;  /* display settings for this window */
 	View view;              /* currently displayed part of underlying text */
 	bool expandtab;         /* whether typed tabs should be converted to spaces in this window*/

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -2198,6 +2198,7 @@ static const struct luaL_Reg window_funcs[] = {
  * @tfield[opt=false] boolean expandtab {et}
  * @tfield[opt=false] boolean numbers {nu}
  * @tfield[opt=false] boolean relativenumbers {rnu}
+ * @tfield[opt=0] int numberwidth
  * @tfield[opt=true] boolean showeof
  * @tfield[opt=false] boolean shownewlines
  * @tfield[opt=false] boolean showspaces

--- a/vis-options.c
+++ b/vis-options.c
@@ -22,6 +22,7 @@ enum {
 	OPTION_STATUSBAR,
 	OPTION_NUMBER,
 	OPTION_NUMBER_RELATIVE,
+	OPTION_NUMBER_WIDTH,
 	OPTION_CURSOR_LINE,
 	OPTION_COLOR_COLUMN,
 	OPTION_SAVE_METHOD,
@@ -93,6 +94,11 @@ static const VisOption vis_options_table[] = {
 		{ "relativenumbers", "rnu" },
 		VIS_OPTION_TYPE_BOOL|VIS_OPTION_NEED_WINDOW,
 		VIS_HELP("Display relative line numbers")
+	},
+	[OPTION_NUMBER_WIDTH] = {
+		{ "numberwidth", "nuw" },
+		VIS_OPTION_TYPE_NUMBER|VIS_OPTION_NEED_WINDOW,
+		VIS_HELP("Minimum sidebar width")
 	},
 	[OPTION_CURSOR_LINE] = {
 		{ "cursorline", "cul" },
@@ -245,6 +251,7 @@ vis_option_set(Vis *vis, Win *win, VisOption *option, VisValue value, bool toggl
 	case OPTION_ESCDELAY:{         termkey_set_waittime(vis->ui.termkey, value.u.integer);              }break;
 	case OPTION_EXPANDTAB:{        win->expandtab = toggle ? !win->expandtab : value.u.boolean;         }break;
 	case OPTION_IGNORECASE:{       vis->ignorecase = toggle ? !vis->ignorecase : value.u.boolean;       }break;
+	case OPTION_NUMBER_WIDTH:{     win->min_sidebar_width = MAX(0, value.u.integer);                    }break;
 	case OPTION_SHELL:{            vis_shell_set(vis, value.u.string);                                  }break;
 	case OPTION_TABWIDTH:{         view_tabwidth_set(&win->view, value.u.integer);                      }break;
 	case OPTION_WRAP_COLUMN:{      win->view.wrapcolumn = MAX(0, value.u.integer);                      }break;
@@ -385,6 +392,7 @@ vis_option_get(Vis *vis, Win *win, VisOption *option)
 		case OPTION_EXPANDTAB:{        result.u.boolean = win->expandtab;                        }break;
 		case OPTION_IGNORECASE:{       result.u.boolean = vis->ignorecase;                       }break;
 		case OPTION_LAYOUT:{           result.u.integer = vis->ui.layout;                        }break;
+		case OPTION_NUMBER_WIDTH:{     result.u.integer = win->min_sidebar_width;                }break;
 		case OPTION_SHELL:{            result.u.string  = vis->shell;                            }break;
 		case OPTION_TABWIDTH:{         result.u.integer = win->view.tabwidth;                    }break;
 		case OPTION_WRAP_COLUMN:{      result.u.integer = win->view.wrapcolumn;                  }break;


### PR DESCRIPTION
This is an option from vim which is quite nice for preventing the source from shifting when you jump across power of 10 line count boundaries. Unlike the implementation in vim we don't clamp the user provided value to 20 because that seems very arbitrary.

closes: #1261