### PR TITLE
lua/lexers: update to scintillua 6.7

### DIFF
--- a/lua/lexers/actionscript.lua
+++ b/lua/lexers/actionscript.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Actionscript LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/ada.lua
+++ b/lua/lexers/ada.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Ada LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/antlr.lua
+++ b/lua/lexers/antlr.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- ANTLR LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/apdl.lua
+++ b/lua/lexers/apdl.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- APDL LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/applescript.lua
+++ b/lua/lexers/applescript.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Applescript LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/arduino.lua
+++ b/lua/lexers/arduino.lua
@@ -1,0 +1,81 @@
+-- Copyright 2026 Jamie Drinkell. See LICENSE.
+-- Arduino LPeg lexer.
+-- Reference: https://docs.arduino.cc/language-reference/
+
+local lexer = lexer
+local lex = lexer.new(..., {inherit = lexer.load('c')})
+
+lex:set_word_list(lexer.KEYWORD, {
+	-- Additional C++ Keywords supported by Arduino.
+	'catch', 'class', 'const_cast', 'delete', 'dynamic_cast', 'explicit', 'export', 'friend',
+	'mutable', 'namespace', 'new', 'operator', 'private', 'protected', 'public', 'reinterpret_cast',
+	'static_cast', 'template', 'this', 'throw', 'try', 'typeid', 'typename', 'using', 'virtual',
+	'and', 'not', 'or', 'xor', -- Operators
+	'final', 'override', -- C++11.
+	'PROGMEM' -- Arduino
+}, true)
+
+lex:set_word_list(lexer.TYPE, 'byte word String', true)
+
+lex:set_word_list(lexer.FUNCTION_BUILTIN, {
+	-- I/O
+	'digitalRead', 'digitalWrite', 'pinMode', 'analogRead', 'analogReadResolution', 'analogReference',
+	'analogWrite', 'analogWriteResolution',
+	-- Adv I/O
+	'noTone', 'pulseIn', 'pulseInLong', 'shiftIn', 'shiftOut', 'tone',
+	-- Time
+	'delay', 'delayMicroseconds', 'micros', 'millis',
+	-- Maths (most are covered by cmath, just adding the missing ones)
+	'abs', 'constrain', 'map', 'max', 'min', 'pow', 'sq', 'exp', 'bit',
+	-- Characters
+	'isAlpha', 'isAlphaNumeric', 'isAscii', 'isControl', 'isDigit', 'isGraph', 'isHexadecimalDigit',
+	'isLowerCase', 'isPrintable', 'isPunct', 'isSpace', 'isUpperCase', 'isWhitespace',
+	-- Random
+	'random', 'randomSeed',
+	-- Bits/Bytes
+	'bit', 'bitClear', 'bitRead', 'bitSet', 'bitWrite', 'highByte', 'lowByte',
+	-- Interrupts
+	'attachInterrupt', 'detachInterrupt', 'digitalPinToInterrupt', 'interrupts', 'noInterrupts',
+	-- Serial
+	'Serial.available', 'Serial.availableForWrite', 'Serial.begin', 'Serial.end', 'Serial.find',
+	'Serial.findUntil', 'Serial.flush', 'Serial.parseFloat', 'Serial.parseInt', 'Serial.peek',
+	'Serial.print', 'Serial.println', 'Serial.read', 'Serial.readBytes', 'Serial.readBytesUntil',
+	'Serial.readString', 'Serial.readStringUntil', 'Serial.setTimeout', 'Serial.write',
+	'Serial.serialEvent',
+	-- EEPROM
+	'EEPROM.read', 'EEPROM.write', 'EEPROM.update', 'EEPROM.get', 'EEPROM.put', 'EEPROM.length',
+	-- SPI
+	'SPISettings', 'SPI.begin', 'SPI.end', 'SPI.beginTransaction', 'SPI.endTransaction',
+	'SPI.usingInterrupt', 'SPI.transfer',
+	-- Wire
+	'Wire.begin', 'Wire.end', 'Wire.setClock', 'Wire.beginTransmission', 'Wire.write',
+	'Wire.endTransmission', 'Wire.requestFrom', 'Wire.available', 'Wire.read', 'Wire.onReceive',
+	'Wire.onRequest', 'Wire.setWireTimeout', 'Wire.getWireTimeoutFlag', 'Wire.clearWireTimeoutFlag',
+	-- Mouse
+	'Mouse.begin', 'Mouse.click', 'Mouse.end', 'Mouse.move', 'Mouse.press', 'Mouse.release',
+	'Mouse.isPressed',
+	-- Keyboard
+	'Keyboard.begin', 'Keyboard.end', 'Keyboard.press', 'Keyboard.print', 'Keyboard.println',
+	'Keyboard.release', 'Keyboard.releaseAll', 'Keyboard.write',
+	-- WiFi
+	-- WiFiClient and WiFiServer require new objects to be made and are hence ommitted
+	'WiFi.begin', 'WiFi.disconnect', 'WiFi.config', 'WiFi.setDNS', 'WiFi.SSID', 'WiFi.BSSID',
+	'WiFi.RSSI', 'WiFi.encryptionType', 'WiFi.scanNetworks', 'WiFi.status', 'WiFi.getSocket',
+	'WiFi.macAddress', 'IPAddress.localIP', 'IPAddress.subnetMask', 'IPAddress.gatewayIP',
+	'WiFiUDP.begin', 'WiFiUDP.available', 'WiFiUDP.beginPacket', 'WiFiUDP.endPacket', 'WiFiUDP.write',
+	'WiFiUDP.parsePacket', 'WiFiUDP.peek', 'WiFiUDP.read', 'WiFiUDP.flush', 'WiFiUDP.stop',
+	'WiFiUDP.remoteIP', 'WiFiUDP.remotePort',
+	-- BLE
+	'BLE.begin', 'BLE.end', 'BLE.poll', 'BLE.setEventHandler', 'BLE.connected', 'BLE.disconnect',
+	'BLE.address', 'BLE.rssi', 'BLE.setAdvertisedServiceUuid', 'BLE.setAdvertisedService',
+	'BLE.setManufacturerData', 'BLE.setLocalName', 'BLE.setDeviceName', 'BLE.setAppearance',
+	'BLE.addService', 'BLE.advertise', 'BLE.stopAdvertise', 'BLE.central',
+	'BLE.setAdvertisingInterval', 'BLE.setConnectionInterval', 'BLE.setConnectable', 'BLE.scan',
+	'BLE.scanForName', 'BLE.scanForAddress', 'BLE.scanForUuid', 'BLE.stopScan', 'BLE.available'
+}, true)
+
+lex:set_word_list(lexer.CONSTANT_BUILTIN, 'HIGH LOW INPUT INPUT_PULLUP OUTPUT LED_BUILTIN', true)
+
+lexer.property['scintillua.comment'] = '//'
+
+return lex

--- a/lua/lexers/asm.lua
+++ b/lua/lexers/asm.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- NASM Assembly LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/asp.lua
+++ b/lua/lexers/asp.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- ASP LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/autohotkey.lua
+++ b/lua/lexers/autohotkey.lua
@@ -1,4 +1,4 @@
--- Copyright 2022-2025 Mitchell. See LICENSE.
+-- Copyright 2022-2026 Mitchell. See LICENSE.
 -- AutoHotkey LPeg lexer.
 -- Contributed by Snoopy.
 

--- a/lua/lexers/autoit.lua
+++ b/lua/lexers/autoit.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- AutoIt LPeg lexer.
 -- Contributed by Jeff Stone.
 

--- a/lua/lexers/awk.lua
+++ b/lua/lexers/awk.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- AWK LPeg lexer.
 -- Modified by Wolfgang Seeberg 2012, 2013.
 

--- a/lua/lexers/bash.lua
+++ b/lua/lexers/bash.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Shell LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/batch.lua
+++ b/lua/lexers/batch.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Batch LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/bibtex.lua
+++ b/lua/lexers/bibtex.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Bibtex LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/boo.lua
+++ b/lua/lexers/boo.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Boo LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/c.lua
+++ b/lua/lexers/c.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- C LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/caml.lua
+++ b/lua/lexers/caml.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- OCaml LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/chuck.lua
+++ b/lua/lexers/chuck.lua
@@ -1,4 +1,4 @@
--- Copyright 2010-2025 Martin Morawetz. See LICENSE.
+-- Copyright 2010-2026 Martin Morawetz. See LICENSE.
 -- ChucK LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/clojure.lua
+++ b/lua/lexers/clojure.lua
@@ -1,4 +1,4 @@
--- Copyright 2018-2025 Mitchell. See LICENSE.
+-- Copyright 2018-2026 Mitchell. See LICENSE.
 -- Clojure LPeg lexer.
 -- Contributed by Christos Chatzifountas.
 

--- a/lua/lexers/cmake.lua
+++ b/lua/lexers/cmake.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- CMake LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/coffeescript.lua
+++ b/lua/lexers/coffeescript.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- CoffeeScript LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/container.lua
+++ b/lua/lexers/container.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Container LPeg lexer.
 -- This is SciTE's plain text lexer.
 

--- a/lua/lexers/cpp.lua
+++ b/lua/lexers/cpp.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- C++ LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/crystal.lua
+++ b/lua/lexers/crystal.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Copyright 2017 Michel Martens.
 -- Crystal LPeg lexer (based on Ruby).
 

--- a/lua/lexers/csharp.lua
+++ b/lua/lexers/csharp.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- C# LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/css.lua
+++ b/lua/lexers/css.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- CSS LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/cuda.lua
+++ b/lua/lexers/cuda.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- CUDA LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/d.lua
+++ b/lua/lexers/d.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- D LPeg lexer.
 -- Heavily modified by Brian Schott (@Hackerpilot on Github).
 

--- a/lua/lexers/dart.lua
+++ b/lua/lexers/dart.lua
@@ -1,4 +1,4 @@
--- Copyright 2013-2025 Mitchell. See LICENSE.
+-- Copyright 2013-2026 Mitchell. See LICENSE.
 -- Dart LPeg lexer.
 -- Written by Brian Schott (@Hackerpilot on Github).
 -- Migrated by Jamie Drinkell
@@ -12,8 +12,11 @@ local lex = lexer.new(...)
 lex:add_rule('keyword', lex:tag(lexer.KEYWORD, lex:word_match(lexer.KEYWORD)))
 -- Built-ins.
 lex:add_rule('constant', lex:tag(lexer.CONSTANT_BUILTIN, lex:word_match(lexer.CONSTANT_BUILTIN)))
--- Types.
-lex:add_rule('type', lex:tag(lexer.TYPE, lex:word_match(lexer.TYPE)))
+
+-- Types (including capitalized words).
+local capitalized_word = P('_')^-1 * lexer.upper * (lexer.alnum + '_')^0
+lex:add_rule('type', lex:tag(lexer.TYPE, lex:word_match(lexer.TYPE) + capitalized_word))
+
 -- Directives
 lex:add_rule('directive', lex:tag(lexer.PREPROCESSOR, lex:word_match(lexer.PREPROCESSOR)))
 
@@ -54,7 +57,8 @@ lex:set_word_list(lexer.KEYWORD, {
 	'covariant', 'default', 'do', 'else', 'enum', 'extends', 'factory', 'finally', 'for', 'get', 'if',
 	'implements', 'in', 'interface', 'is', 'mixin', 'on', 'operator', 'rethrow', 'return', 'set',
 	'super', 'switch', 'sync', 'this', 'throw', 'try', 'with', 'while', 'yield', --
-	'base', 'extension', 'external', 'late', 'of', 'required', 'sealed', 'when'
+	'base', 'extension', 'external', 'late', 'of', 'required', 'sealed', 'when', --
+	'typedef', 'void', 'var', 'const', 'final', 'new', 'static'
 })
 
 lex:set_word_list(lexer.PREPROCESSOR, {
@@ -66,9 +70,7 @@ lex:set_word_list(lexer.CONSTANT_BUILTIN, {
 })
 
 lex:set_word_list(lexer.TYPE, {
-	'const', 'dynamic', 'final', 'Function', 'new', 'static', 'typedef', 'var', 'void', 'int',
-	'double', 'String', 'bool', 'List', 'Set', 'Map', 'Future', 'Stream', 'Iterable', 'Object',
-	'Null', 'type'
+	'dynamic', 'int', 'double', 'bool', 'type'
 })
 
 lexer.property['scintillua.comment'] = '//'

--- a/lua/lexers/desktop.lua
+++ b/lua/lexers/desktop.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Desktop Entry LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/diff.lua
+++ b/lua/lexers/diff.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Diff LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/django.lua
+++ b/lua/lexers/django.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Django LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/eiffel.lua
+++ b/lua/lexers/eiffel.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Eiffel LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/elixir.lua
+++ b/lua/lexers/elixir.lua
@@ -1,4 +1,4 @@
--- Copyright 2015-2025 Mitchell. See LICENSE.
+-- Copyright 2015-2026 Mitchell. See LICENSE.
 -- Contributed by Richard Philips.
 -- Elixir LPeg lexer.
 

--- a/lua/lexers/elm.lua
+++ b/lua/lexers/elm.lua
@@ -1,4 +1,4 @@
--- Copyright 2020-2025 Mitchell. See LICENSE.
+-- Copyright 2020-2026 Mitchell. See LICENSE.
 -- Elm LPeg lexer
 -- Adapted from Haskell LPeg lexer by Karl Schultheisz.
 

--- a/lua/lexers/erlang.lua
+++ b/lua/lexers/erlang.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Erlang LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/fennel.lua
+++ b/lua/lexers/fennel.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Fennel LPeg lexer.
 -- Contributed by Momohime Honda.
 

--- a/lua/lexers/forth.lua
+++ b/lua/lexers/forth.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Forth LPeg lexer.
 -- Contributions from Joseph Eib.
 

--- a/lua/lexers/fortran.lua
+++ b/lua/lexers/fortran.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Fortran LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/fsharp.lua
+++ b/lua/lexers/fsharp.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- F# LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/gap.lua
+++ b/lua/lexers/gap.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Gap LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/gettext.lua
+++ b/lua/lexers/gettext.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Gettext LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/git-rebase.lua
+++ b/lua/lexers/git-rebase.lua
@@ -1,4 +1,4 @@
--- Copyright 2017-2025 Marc André Tanner. See LICENSE.
+-- Copyright 2017-2026 Marc André Tanner. See LICENSE.
 -- git-rebase(1) LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/gleam.lua
+++ b/lua/lexers/gleam.lua
@@ -1,4 +1,4 @@
--- Copyright 2021-2025 Mitchell. See LICENSE.
+-- Copyright 2021-2026 Mitchell. See LICENSE.
 -- Gleam LPeg lexer
 -- https://gleam.run/
 -- Contributed by Tynan Beatty

--- a/lua/lexers/glsl.lua
+++ b/lua/lexers/glsl.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- GLSL LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/gnuplot.lua
+++ b/lua/lexers/gnuplot.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Gnuplot LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/go.lua
+++ b/lua/lexers/go.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Go LPeg lexer.
 
 local lexer = lexer
@@ -62,8 +62,8 @@ lex:set_word_list(lexer.TYPE, {
 })
 
 lex:set_word_list(lexer.FUNCTION_BUILTIN, {
-	'append', 'cap', 'close', 'complex', 'copy', 'delete', 'imag', 'len', 'make', 'new', 'panic',
-	'print', 'println', 'real', 'recover'
+	'append', 'cap', 'clear', 'close', 'complex', 'copy', 'delete', 'imag', 'len', 'make', 'max',
+	'min', 'new', 'panic', 'print', 'println', 'real', 'recover'
 })
 
 lexer.property['scintillua.comment'] = '//'

--- a/lua/lexers/groovy.lua
+++ b/lua/lexers/groovy.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Groovy LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/gtkrc.lua
+++ b/lua/lexers/gtkrc.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Gtkrc LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/hare.lua
+++ b/lua/lexers/hare.lua
@@ -1,4 +1,4 @@
--- Copyright 2021-2025 Mitchell. See LICENSE.
+-- Copyright 2021-2026 Mitchell. See LICENSE.
 -- Hare LPeg lexer
 
 local lexer = lexer

--- a/lua/lexers/haskell.lua
+++ b/lua/lexers/haskell.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Haskell LPeg lexer.
 -- Modified by Alex Suraci.
 -- Migrated by Samuel Marquis.

--- a/lua/lexers/html.lua
+++ b/lua/lexers/html.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- HTML LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/icon.lua
+++ b/lua/lexers/icon.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- LPeg lexer for the Icon programming language.
 -- http://www.cs.arizona.edu/icon
 -- Contributed by Carl Sturtivant.

--- a/lua/lexers/idl.lua
+++ b/lua/lexers/idl.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- IDL LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/ini.lua
+++ b/lua/lexers/ini.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Ini LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/io_lang.lua
+++ b/lua/lexers/io_lang.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Io LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/java.lua
+++ b/lua/lexers/java.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Java LPeg lexer.
 -- Modified by Brian Schott.
 

--- a/lua/lexers/javascript.lua
+++ b/lua/lexers/javascript.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- JavaScript LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/jq.lua
+++ b/lua/lexers/jq.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- jq 1.6 Lua lexer -- https://stedolan.github.io/jq/wiki
 -- Anonymously contributed.
 

--- a/lua/lexers/jsp.lua
+++ b/lua/lexers/jsp.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- JSP LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/latex.lua
+++ b/lua/lexers/latex.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Latex LPeg lexer.
 -- Modified by Brian Schott.
 -- Modified by Robert Gieseke.
@@ -16,7 +16,8 @@ local block_comment = lexer.range('\\begin' * P(' ')^0 * '{comment}',
 lex:add_rule('comment', lex:tag(lexer.COMMENT, line_comment + block_comment))
 
 -- Math environments.
-local math_word = word_match('align displaymath eqnarray equation gather math multline')
+local math_word = word_match(
+	'align alignat displaymath eqnarray equation flalign gather math multline')
 local math_begin_end = (P('begin') + P('end')) * P(' ')^0 * '{' * math_word * P('*')^-1 * '}'
 lex:add_rule('math', lex:tag('environment.math', '$' + '\\' * (S('[]()') + math_begin_end)))
 

--- a/lua/lexers/lexer.lua
+++ b/lua/lexers/lexer.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 
 --- Lexes Scintilla documents and source code with Lua and LPeg.
 --
@@ -1662,10 +1662,20 @@ end
 -- @usage lexer.detect_extensions.luadoc = 'lua'
 M.detect_extensions = {}
 
+--- Map of file extensions (without the '.' prefix) to strip from filenames during detection to
+-- `true`.
+-- @usage lexer.ignore_extensions.backup = true
+M.ignore_extensions = {orig = true, back = true, old = true, new = true}
+
 --- Map of first-line patterns to their associated lexer names.
 -- These are Lua string patterns, not LPeg patterns.
 -- @usage lexer.detect_patterns['^#!.+/zsh'] = 'bash'
 M.detect_patterns = {}
+
+--- List of filename parts to strip from filenames during detection.
+-- Filename parts are expressed as Lua patterns.
+-- @usage table.insert(lexer.ignore_patterns, '%.%d+$') -- ignore digit extensions
+M.ignore_patterns = {'~+$'}
 
 --- Returns the name of the lexer often associated a particular filename and/or file content.
 -- @param[opt] filename String filename to inspect. The default value is read from the
@@ -1685,6 +1695,7 @@ function M.detect(filename, line)
 		ans = 'apdl', inp = 'apdl', mac = 'apdl', --
 		apl = 'apl', --
 		applescript = 'applescript', --
+		ino = 'arduino', --
 		asm = 'asm', ASM = 'asm', s = 'asm', S = 'asm', --
 		asa = 'asp', asp = 'asp', hta = 'asp', --
 		ahk = 'autohotkey', --
@@ -1694,8 +1705,8 @@ function M.detect(filename, line)
 		bib = 'bibtex', --
 		boo = 'boo', --
 		cs = 'csharp', --
-		c = 'c', C = 'c', cc = 'cpp', cpp = 'cpp', cxx = 'cpp', ['c++'] = 'cpp', h = 'cpp', hh = 'cpp',
-		hpp = 'cpp', hxx = 'cpp', ['h++'] = 'cpp', --
+		c = 'c', C = 'c', cc = 'cpp', cpp = 'cpp', cxx = 'cpp', ['c++'] = 'cpp', h = 'cpp', H = 'cpp',
+		hh = 'cpp', hpp = 'cpp', hxx = 'cpp', ['h++'] = 'cpp', --
 		ck = 'chuck', --
 		clj = 'clojure', cljs = 'clojure', cljc = 'clojure', edn = 'clojure', --
 		['CMakeLists.txt'] = 'cmake', cmake = 'cmake', ['cmake.in'] = 'cmake', ctest = 'cmake',
@@ -1707,7 +1718,7 @@ function M.detect(filename, line)
 		d = 'd', di = 'd', --
 		dart = 'dart', --
 		desktop = 'desktop', --
-		diff = 'diff', patch = 'diff', --
+		diff = 'diff', patch = 'diff', rej = 'diff', --
 		Dockerfile = 'dockerfile', --
 		dot = 'dot', --
 		e = 'eiffel', eif = 'eiffel', --
@@ -1744,7 +1755,7 @@ function M.detect(filename, line)
 		io = 'io_lang', --
 		janet = 'janet', --
 		bsh = 'java', java = 'java', --
-		js = 'javascript', jsfl = 'javascript', --
+		cjs = 'javascript', js = 'javascript', jsfl = 'javascript', mjs = 'javascript', --
 		jq = 'jq', --
 		json = 'json', --
 		jsp = 'jsp', --
@@ -1758,7 +1769,7 @@ function M.detect(filename, line)
 		lgt = 'logtalk', --
 		lua = 'lua', --
 		GNUmakefile = 'makefile', iface = 'makefile', mak = 'makefile', makefile = 'makefile',
-		Makefile = 'makefile', --
+		Makefile = 'makefile', mk = 'makefile', --
 		md = 'markdown', markdown = 'markdown', --
 		['meson.build'] = 'meson', --
 		moon = 'moonscript', --
@@ -1773,19 +1784,19 @@ function M.detect(filename, line)
 		caml = 'caml', ml = 'caml', mli = 'caml', mll = 'caml', mly = 'caml', --
 		org = 'org', --
 		dpk = 'pascal', dpr = 'pascal', p = 'pascal', pas = 'pascal', pp = 'pascal', --
-		al = 'perl', perl = 'perl', pl = 'perl', pm = 'perl', pod = 'perl', --
+		al = 'perl', perl = 'perl', pl = 'perl', PL = 'perl', pm = 'perl', pod = 'perl', --
 		inc = 'php', php = 'php', php3 = 'php', php4 = 'php', phtml = 'php', --
 		p8 = 'pico8', --
 		pike = 'pike', pmod = 'pike', --
 		PKGBUILD = 'pkgbuild', --
 		pony = 'pony', --
 		eps = 'ps', ps = 'ps', --
-		ps1 = 'powershell', --
+		ps1 = 'powershell', psm1 = 'powershell', --
 		prolog = 'prolog', --
 		props = 'props', properties = 'props', --
 		proto = 'protobuf', --
 		pure = 'pure', --
-		sc = 'python', py = 'python', pyw = 'python', --
+		sc = 'python', py = 'python', pyi = 'python', pyw = 'python', --
 		R = 'r', Rout = 'r', Rhistory = 'r', Rt = 'r', ['Rout.save'] = 'r', ['Rout.fail'] = 'r', --
 		re = 'reason', --
 		r = 'rebol', reb = 'rebol', --
@@ -1806,6 +1817,7 @@ function M.detect(filename, line)
 		sno = 'snobol4', SNO = 'snobol4', --
 		spin = 'spin', --
 		ddl = 'sql', sql = 'sql', --
+		swift = 'swift', --
 		automount = 'systemd', device = 'systemd', mount = 'systemd', path = 'systemd',
 		scope = 'systemd', service = 'systemd', slice = 'systemd', socket = 'systemd', swap = 'systemd',
 		target = 'systemd', timer = 'systemd', --
@@ -1848,8 +1860,16 @@ function M.detect(filename, line)
 	for patt, name in pairs(M.detect_patterns) do if line:find(patt) then return name end end
 	for patt, name in pairs(patterns) do if line:find(patt) then return name end end
 	local name, ext = filename:match('[^/\\]+$'), filename:match('[^.]*$')
-	return M.detect_extensions[name] or extensions[name] or M.detect_extensions[ext] or
+	local detected = M.detect_extensions[name] or extensions[name] or M.detect_extensions[ext] or
 		extensions[ext]
+	if detected then return detected end
+
+	-- Strip ignored filename parts and extensions, and try again.
+	-- Do not do this first for the sake of performance; this should be a fallback option.
+	for _, patt in ipairs(M.ignore_patterns) do filename = filename:gsub(patt, '') end
+	ext = filename:match('[^.]*$')
+	while M.ignore_extensions[ext] do filename, ext = filename:match('^(.-%.?([^.]*))%.[^.]+$') end
+	return M.detect_extensions[ext] or extensions[ext]
 end
 
 -- The following are utility functions lexers will have access to.

--- a/lua/lexers/lisp.lua
+++ b/lua/lexers/lisp.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Lisp LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/logtalk.lua
+++ b/lua/lexers/logtalk.lua
@@ -1,4 +1,4 @@
--- Copyright © 2017-2025 Michael T. Richter <ttmrichter@gmail.com>. See LICENSE.
+-- Copyright © 2017-2026 Michael T. Richter <ttmrichter@gmail.com>. See LICENSE.
 -- Logtalk LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/lua.lua
+++ b/lua/lexers/lua.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Lua LPeg lexer.
 -- Original written by Peter Odding, 2007/04/04.
 
@@ -81,7 +81,8 @@ lex:add_fold_point(lexer.OPERATOR, '{', '}')
 lex:set_word_list(lexer.KEYWORD, {
 	'and', 'break', 'do', 'else', 'elseif', 'end', 'false', 'for', 'function', 'if', 'in', 'local',
 	'or', 'nil', 'not', 'repeat', 'return', 'then', 'true', 'until', 'while', --
-	'goto' -- 5.2
+	'goto', -- 5.2
+	'global' -- 5.5
 })
 
 lex:set_word_list(lexer.FUNCTION_BUILTIN, {
@@ -107,9 +108,11 @@ lex:set_word_list(lexer.FUNCTION_BUILTIN .. '.library', {
 	'table.concat', 'table.insert', 'table.remove', 'table.sort', --
 	'table.pack', 'table.unpack', -- 5.2
 	'table.move', -- 5.3
+	'table.create', -- 5.5
 	'math.abs', 'math.acos', 'math.asin', 'math.atan', 'math.ceil', 'math.cos', 'math.deg',
-	'math.exp', 'math.floor', 'math.fmod', 'math.log', 'math.max', 'math.min', 'math.modf',
-	'math.rad', 'math.random', 'math.randomseed', 'math.sin', 'math.sqrt', 'math.tan', --
+	'math.exp', 'math.floor', 'math.fmod', 'math.frexp', 'math.ldexp', 'math.log', 'math.max',
+	'math.min', 'math.modf', 'math.rad', 'math.random', 'math.randomseed', 'math.sin', 'math.sqrt',
+	'math.tan', --
 	'math.tointeger', 'math.type', 'math.ult', -- 5.3
 	'io.close', 'io.flush', 'io.input', 'io.lines', 'io.open', 'io.output', 'io.popen', 'io.read',
 	'io.tmpfile', 'io.type', 'io.write', --

--- a/lua/lexers/makefile.lua
+++ b/lua/lexers/makefile.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Makefile LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/markdown.lua
+++ b/lua/lexers/markdown.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Markdown LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/matlab.lua
+++ b/lua/lexers/matlab.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Martin Morawetz. See LICENSE.
+-- Copyright 2006-2026 Martin Morawetz. See LICENSE.
 -- Matlab LPeg lexer.
 -- Based off of lexer code by Mitchell.
 

--- a/lua/lexers/mediawiki.lua
+++ b/lua/lexers/mediawiki.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- MediaWiki LPeg lexer.
 -- Contributed by Alexander Misel.
 

--- a/lua/lexers/myrddin.lua
+++ b/lua/lexers/myrddin.lua
@@ -1,4 +1,4 @@
--- Copyright 2017-2025 Michael Forney. See LICENSE
+-- Copyright 2017-2026 Michael Forney. See LICENSE
 -- Myrddin LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/nemerle.lua
+++ b/lua/lexers/nemerle.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Nemerle LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/nim.lua
+++ b/lua/lexers/nim.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Nim LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/null.lua
+++ b/lua/lexers/null.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Null LPeg lexer.
 
 return require('lexer').new('null')

--- a/lua/lexers/objeck.lua
+++ b/lua/lexers/objeck.lua
@@ -1,4 +1,4 @@
--- Copyright 2023-2025 Mitchell. See LICENSE.
+-- Copyright 2023-2026 Mitchell. See LICENSE.
 -- Objeck LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/objective_c.lua
+++ b/lua/lexers/objective_c.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Objective C LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/org.lua
+++ b/lua/lexers/org.lua
@@ -1,4 +1,4 @@
--- Copyright 2025 Matěj Cepl (@mcepl everywhere). See LICENSE.
+-- Copyright 2025-2026 Matěj Cepl (@mcepl everywhere). See LICENSE.
 -- Copyright 2012 joten
 -- Org agenda LPeg lexer.
 

--- a/lua/lexers/output.lua
+++ b/lua/lexers/output.lua
@@ -1,4 +1,4 @@
--- Copyright 2022-2025 Mitchell. See LICENSE.
+-- Copyright 2022-2026 Mitchell. See LICENSE.
 -- LPeg lexer for tool output.
 -- If a warning or error is recognized, tags its filename, line, column (if available),
 -- and message, and sets the line state to 1 for an error (first bit), and 2 for a warning

--- a/lua/lexers/pascal.lua
+++ b/lua/lexers/pascal.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Pascal LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/perl.lua
+++ b/lua/lexers/perl.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Perl LPeg lexer.
 
 local lexer = lexer
@@ -56,9 +56,9 @@ local sq_str = lexer.range("'")
 local dq_str = lexer.range('"')
 local cmd_str = lexer.range('`')
 local heredoc = '<<' * P(function(input, index)
-	local s, e, delimiter = input:find('([%a_][%w_]*)[\n\r\f;]+', index)
+	local s, e, indented, _, delimiter = input:find('(~?)(["\'`]?)([%a_][%w_]*)%2[\n\r\f;]+', index)
 	if s == index and delimiter then
-		local end_heredoc = '[\n\r\f]+'
+		local end_heredoc = (#indented > 0 and '[\n\r\f]+ *' or '[\n\r\f]+')
 		e = select(2, input:find(end_heredoc .. delimiter, e))
 		return e and e + 1 or #input + 1
 	end
@@ -68,11 +68,13 @@ local lit_array = 'qw' * literal_delimited
 local lit_cmd = 'qx' * literal_delimited
 local string = lex:tag(lexer.STRING,
 	sq_str + dq_str + cmd_str + heredoc + lit_str + lit_array + lit_cmd)
-local regex_str = lexer.after_set('-<>+*!~\\=%&|^?:;([{', lexer.range('/', true) * S('imosx')^0)
+local regex_range = lexer.range('/', true) * S('cgimosx')^0
+local regex_str = lexer.after_set('-<>+*!~\\=%&|^?:;([{', regex_range) +
+	(regex_range * #(lexer.space^0 * ','))
 local lit_regex = 'qr' * literal_delimited * S('imosx')^0
 local lit_match = 'm' * literal_delimited * S('cgimosx')^0
-local lit_sub = 's' * literal_delimited2 * S('ecgimosx')^0
-local lit_tr = (P('tr') + 'y') * literal_delimited2 * S('cds')^0
+local lit_sub = 's' * literal_delimited2 * S('ecgimosxr')^0
+local lit_tr = (P('tr') + 'y') * literal_delimited2 * S('cdsr')^0
 local regex = lex:tag(lexer.REGEX, regex_str + lit_regex + lit_match + lit_sub + lit_tr)
 lex:add_rule('string', string + regex)
 
@@ -108,7 +110,7 @@ lex:add_rule('variable_builtin',
 local special_var = '$' *
 	('^' * S('ADEFHILMOPSTWX')^-1 + S('\\"[]\'&`+*.,;=%~?@<>(|/!-') + ':' * (lexer.any - ':') +
 		(P('$') * -lexer.word) + lexer.digit^1)
-local plain_var = ('$#' + S('$@%')) * P('$')^0 * lexer.word + '$#'
+local plain_var = ('$#' + S('$@%&*')) * P('$')^0 * lexer.word + '$#'
 lex:add_rule('variable', lex:tag(lexer.VARIABLE, special_var + plain_var))
 
 -- Operators.
@@ -120,36 +122,38 @@ lex:add_fold_point(lexer.OPERATOR, '{', '}')
 
 -- Word lists.
 lex:set_word_list(lexer.KEYWORD, {
-	'STDIN', 'STDOUT', 'STDERR', 'BEGIN', 'END', 'CHECK', 'INIT', --
+	'STDIN', 'STDOUT', 'STDERR', 'BEGIN', 'END', 'CHECK', 'INIT', 'UNITCHECK', 'CLONE', 'CLONE_SKIP',
+	'DESTROY', 'AUTOLOAD', --
 	'require', 'use', --
 	'break', 'continue', 'do', 'each', 'else', 'elsif', 'foreach', 'for', 'if', 'last', 'local', 'my',
-	'next', 'our', 'package', 'return', 'sub', 'unless', 'until', 'while', '__FILE__', '__LINE__',
-	'__PACKAGE__', --
-	'and', 'or', 'not', 'eq', 'ne', 'lt', 'gt', 'le', 'ge'
+	'next', 'our', 'package', 'return', 'state', 'sub', 'unless', 'until', 'while', '__FILE__',
+	'__LINE__', '__PACKAGE__', '__SUB__', --
+	'and', 'or', 'not', 'eq', 'ne', 'lt', 'gt', 'le', 'ge', 'xor'
 })
 
 lex:set_word_list(lexer.FUNCTION_BUILTIN, {
 	'abs', 'accept', 'alarm', 'atan2', 'bind', 'binmode', 'bless', 'caller', 'chdir', 'chmod',
 	'chomp', 'chop', 'chown', 'chr', 'chroot', 'closedir', 'close', 'connect', 'cos', 'crypt',
 	'dbmclose', 'dbmopen', 'defined', 'delete', 'die', 'dump', 'each', 'endgrent', 'endhostent',
-	'endnetent', 'endprotoent', 'endpwent', 'endservent', 'eof', 'eval', 'exec', 'exists', 'exit',
-	'exp', 'fcntl', 'fileno', 'flock', 'fork', 'format', 'formline', 'getc', 'getgrent', 'getgrgid',
-	'getgrnam', 'gethostbyaddr', 'gethostbyname', 'gethostent', 'getlogin', 'getnetbyaddr',
-	'getnetbyname', 'getnetent', 'getpeername', 'getpgrp', 'getppid', 'getpriority', 'getprotobyname',
-	'getprotobynumber', 'getprotoent', 'getpwent', 'getpwnam', 'getpwuid', 'getservbyname',
-	'getservbyport', 'getservent', 'getsockname', 'getsockopt', 'glob', 'gmtime', 'goto', 'grep',
-	'hex', 'import', 'index', 'int', 'ioctl', 'join', 'keys', 'kill', 'lcfirst', 'lc', 'length',
-	'link', 'listen', 'localtime', 'log', 'lstat', 'map', 'mkdir', 'msgctl', 'msgget', 'msgrcv',
-	'msgsnd', 'new', 'oct', 'opendir', 'open', 'ord', 'pack', 'pipe', 'pop', 'pos', 'printf', 'print',
-	'prototype', 'push', 'quotemeta', 'rand', 'readdir', 'read', 'readlink', 'recv', 'redo', 'ref',
-	'rename', 'reset', 'reverse', 'rewinddir', 'rindex', 'rmdir', 'scalar', 'seekdir', 'seek',
-	'select', 'semctl', 'semget', 'semop', 'send', 'setgrent', 'sethostent', 'setnetent', 'setpgrp',
-	'setpriority', 'setprotoent', 'setpwent', 'setservent', 'setsockopt', 'shift', 'shmctl', 'shmget',
-	'shmread', 'shmwrite', 'shutdown', 'sin', 'sleep', 'socket', 'socketpair', 'sort', 'splice',
-	'split', 'sprintf', 'sqrt', 'srand', 'stat', 'study', 'substr', 'symlink', 'syscall', 'sysread',
-	'sysseek', 'system', 'syswrite', 'telldir', 'tell', 'tied', 'tie', 'time', 'times', 'truncate',
-	'ucfirst', 'uc', 'umask', 'undef', 'unlink', 'unpack', 'unshift', 'untie', 'utime', 'values',
-	'vec', 'wait', 'waitpid', 'wantarray', 'warn', 'write'
+	'endnetent', 'endprotoent', 'endpwent', 'endservent', 'eof', 'eval', 'evalbytes', 'exec',
+	'exists', 'exit', 'exp', 'fc', 'fcntl', 'fileno', 'flock', 'fork', 'format', 'formline', 'getc',
+	'getgrent', 'getgrgid', 'getgrnam', 'gethostbyaddr', 'gethostbyname', 'gethostent', 'getlogin',
+	'getnetbyaddr', 'getnetbyname', 'getnetent', 'getpeername', 'getpgrp', 'getppid', 'getpriority',
+	'getprotobyname', 'getprotobynumber', 'getprotoent', 'getpwent', 'getpwnam', 'getpwuid',
+	'getservbyname', 'getservbyport', 'getservent', 'getsockname', 'getsockopt', 'glob', 'gmtime',
+	'goto', 'grep', 'hex', 'import', 'index', 'int', 'ioctl', 'join', 'keys', 'kill', 'lcfirst', 'lc',
+	'length', 'link', 'listen', 'localtime', 'lock', 'log', 'lstat', 'map', 'mkdir', 'msgctl',
+	'msgget', 'msgrcv', 'msgsnd', 'new', 'oct', 'opendir', 'open', 'ord', 'pack', 'pipe', 'pop',
+	'pos', 'printf', 'print', 'prototype', 'push', 'quotemeta', 'rand', 'readdir', 'read', 'readline',
+	'readlink', 'readpipe', 'recv', 'redo', 'ref', 'rename', 'reset', 'reverse', 'rewinddir',
+	'rindex', 'rmdir', 'say', 'scalar', 'seekdir', 'seek', 'select', 'semctl', 'semget', 'semop',
+	'send', 'setgrent', 'sethostent', 'setnetent', 'setpgrp', 'setpriority', 'setprotoent',
+	'setpwent', 'setservent', 'setsockopt', 'shift', 'shmctl', 'shmget', 'shmread', 'shmwrite',
+	'shutdown', 'sin', 'sleep', 'socket', 'socketpair', 'sort', 'splice', 'split', 'sprintf', 'sqrt',
+	'srand', 'stat', 'study', 'substr', 'symlink', 'syscall', 'sysopen', 'sysread', 'sysseek',
+	'system', 'syswrite', 'telldir', 'tell', 'tied', 'tie', 'time', 'times', 'truncate', 'ucfirst',
+	'uc', 'umask', 'undef', 'unlink', 'unpack', 'unshift', 'untie', 'utime', 'values', 'vec', 'wait',
+	'waitpid', 'wantarray', 'warn', 'write'
 })
 
 lex:set_word_list(lexer.CONSTANT_BUILTIN, {

--- a/lua/lexers/php.lua
+++ b/lua/lexers/php.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- PHP LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/pike.lua
+++ b/lua/lexers/pike.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Pike LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/pkgbuild.lua
+++ b/lua/lexers/pkgbuild.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 gwash. See LICENSE.
+-- Copyright 2006-2026 gwash. See LICENSE.
 -- Archlinux PKGBUILD LPeg lexer.
 
 local lexer = require('lexer')
@@ -27,13 +27,13 @@ end)
 lex:add_rule('string', token(lexer.STRING, sq_str + dq_str + ex_str + heredoc))
 
 -- Numbers.
-lex:add_rule('number', token(lexer.NUMBER, lexer.number))
+lex:add_rule('number', token(lexer.NUMBER, lexer.number * -lexer.alpha))
 
 -- Keywords.
-lex:add_rule('keyword', token(lexer.KEYWORD, word_match{
+lex:add_rule('keyword', token(lexer.KEYWORD, -lpeg.B('.') * word_match{
 	'patch', 'cd', 'make', 'patch', 'mkdir', 'cp', 'sed', 'install', 'rm', 'if', 'then', 'elif',
 	'else', 'fi', 'case', 'in', 'esac', 'while', 'for', 'do', 'done', 'continue', 'local', 'return',
-	'git', 'svn', 'co', 'clone', 'gconf-merge-schema', 'msg', 'echo', 'ln',
+	'git', 'svn', 'co', 'clone', 'gconf-merge-schema', 'msg', 'echo', 'ln', 'tar', 'bsdtar',
 	-- Operators.
 	'-a', '-b', '-c', '-d', '-e', '-f', '-g', '-h', '-k', '-p', '-r', '-s', '-t', '-u', '-w', '-x',
 	'-O', '-G', '-L', '-S', '-N', '-nt', '-ot', '-ef', '-o', '-z', '-n', '-eq', '-ne', '-lt', '-le',
@@ -42,17 +42,21 @@ lex:add_rule('keyword', token(lexer.KEYWORD, word_match{
 
 -- Functions.
 lex:add_rule('function',
-	token(lexer.FUNCTION, word_match('build check package pkgver prepare') * '()'))
+	token(lexer.FUNCTION, word_match('build check package pkgver prepare verify') * '()'))
 
 -- Constants.
-lex:add_rule('constant', token(lexer.CONSTANT, word_match{
+local constant = word_match{
 	-- We do *not* list pkgver srcdir and startdir here.
 	-- These are defined by makepkg but user should not alter them.
-	'arch', 'backup', 'changelog', 'checkdepends', 'conflicts', 'depends', 'epoch', 'groups',
-	'install', 'license', 'makedepends', 'md5sums', 'noextract', 'optdepends', 'options', 'pkgbase',
-	'pkgdesc', 'pkgname', 'pkgrel', 'pkgver', 'provides', 'replaces', 'sha1sums', 'sha256sums',
-	'sha384sums', 'sha512sums', 'source', 'url', 'validpgpkeys'
-}))
+	'arch', 'backup', 'changelog', 'epoch', 'groups', 'install', 'license', 'noextract', 'options',
+	'pkgbase', 'pkgdesc', 'pkgname', 'pkgrel', 'pkgver', 'url', 'validpgpkeys'
+}
+-- Note: cannot use word_match because it matches '_', which consumes arch suffix.
+local arch_constant =
+	(P('source') + 'cksums' + 'md5sums' + 'sha1sums' + 'sha224sums' + 'sha256sums' + 'sha384sums' +
+		'sha512sums' + 'b2sums' + 'depends' + 'makedepends' + 'checkdepends' + 'optdepends' +
+		'conflicts' + 'provides' + 'replaces') * ('_' * lexer.word)^-1 -- e.g. source_x86_64
+lex:add_rule('constant', token(lexer.CONSTANT, constant + arch_constant))
 
 -- Identifiers.
 lex:add_rule('identifier', token(lexer.IDENTIFIER, lexer.word))

--- a/lua/lexers/pony.lua
+++ b/lua/lexers/pony.lua
@@ -1,4 +1,4 @@
--- Copyright 2017-2025 Murray Calavera. See LICENSE.
+-- Copyright 2017-2026 Murray Calavera. See LICENSE.
 -- Pony LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/powershell.lua
+++ b/lua/lexers/powershell.lua
@@ -1,4 +1,4 @@
--- Copyright 2015-2025 Mitchell. See LICENSE.
+-- Copyright 2015-2026 Mitchell. See LICENSE.
 -- PowerShell LPeg lexer.
 -- Contributed by Jeff Stone.
 

--- a/lua/lexers/prolog.lua
+++ b/lua/lexers/prolog.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Lexer enhanced to conform to the realities of Prologs on the ground by
 -- Michael T. Richter.  Copyright is explicitly assigned back to Mitchell.
 -- Prolog LPeg lexer.

--- a/lua/lexers/props.lua
+++ b/lua/lexers/props.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Props LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/ps.lua
+++ b/lua/lexers/ps.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Postscript LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/python.lua
+++ b/lua/lexers/python.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Python LPeg lexer.
 
 local lexer = lexer
@@ -98,7 +98,7 @@ lex:set_word_list(lexer.FUNCTION_BUILTIN .. '.special', {
 })
 
 lex:set_word_list(lexer.CONSTANT_BUILTIN, {
-	'BaseException', 'Exception', 'Exception', 'ArithmeticError', 'BufferError', 'LookupError', --
+	'BaseException', 'Exception', 'ArithmeticError', 'BufferError', 'LookupError', --
 	'AssertionError', 'AttributeError', 'EOFError', 'FloatingPointError', 'GeneratorExit',
 	'ImportError', 'ModuleNotFoundError', 'IndexError', 'KeyError', 'KeyboardInterrupt',
 	'MemoryError', 'NameError', 'NotImplementedError', 'OSError', 'OverflowError', 'RecursionError',

--- a/lua/lexers/r.lua
+++ b/lua/lexers/r.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- R LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/rails.lua
+++ b/lua/lexers/rails.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Ruby on Rails LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/rc.lua
+++ b/lua/lexers/rc.lua
@@ -1,4 +1,4 @@
--- Copyright 2017-2025 Michael Forney. See LICENSE.
+-- Copyright 2017-2026 Michael Forney. See LICENSE.
 -- rc LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/rebol.lua
+++ b/lua/lexers/rebol.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Rebol LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/rest.lua
+++ b/lua/lexers/rest.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- reStructuredText LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/rexx.lua
+++ b/lua/lexers/rexx.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Rexx LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/rhtml.lua
+++ b/lua/lexers/rhtml.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- RHTML LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/routeros.lua
+++ b/lua/lexers/routeros.lua
@@ -1,4 +1,4 @@
--- Copyright 2020-2025 Christian Hesse. See LICENSE.
+-- Copyright 2020-2026 Christian Hesse. See LICENSE.
 -- Mikrotik RouterOS script LPeg lexer.
 
 local lexer = require('lexer')
@@ -12,21 +12,26 @@ lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{
+	-- Note: some keywords are widely used, but not available in any context.
+
 	-- Control.
-	':delay', ':do', 'on-error', 'while', ':error', ':foreach', 'in', 'do', ':for', 'from', 'to',
-	'step', ':if', 'do', 'else', ':return', ':while', 'do',
+	':break', ':continue', ':delay', ':do', 'on-error', 'while', ':error', ':exit', ':foreach', 'in',
+	'do', ':for', 'from', 'to', 'step', ':if', 'do', 'else', ':jobname', ':lock', ':onerror',
+	':retry', 'delay', 'max', ':return', ':while', 'do',
 	-- Menu specific commands.
 	'add', 'disable', 'edit', 'enable', 'export', 'find', 'get', 'info', 'monitor', 'print', 'append',
-	'as-value', 'brief', 'count-only', 'detail', 'file', 'follow', 'follow-only', 'from', 'interval',
-	'terse', 'value-list', 'where', 'without-paging', 'remove', 'set',
+	'proplist', 'group-by', 'as-value', 'brief', 'count-only', 'detail', 'file', 'follow',
+	'follow-only', 'from', 'interval', 'terse', 'value-list', 'where', 'without-paging', 'remove',
+	'set', 'reset', 'name',
 	-- Output & string handling.
-	':beep', ':blink', ':environment', ':execute', ':find', ':len', ':log', 'alert', 'critical',
-	'debug', 'emergency', 'error', 'info', 'notice', 'warning', ':parse', ':pick', ':put',
-	':terminal', ':time', ':typeof',
+	':beep', ':blink', ':environment', ':execute', ':find', ':grep', ':len', ':log', 'alert',
+	'critical', 'debug', 'emergency', 'error', 'info', 'notice', 'warning', ':parse', ':pick', ':put',
+	':terminal', ':time', ':timestamp', ':typeof',
 	-- Variable declaration.
 	':global', ':local', ':set',
-	-- Variable casting.
-	':toarray', ':tobool', ':toid', ':toip', ':toip6', ':tonum', ':tostr', ':totime',
+	-- Variable casting and conversion.
+	':convert', ':deserialize', ':range', ':rndnum', ':rndstr', ':serialize', ':toarray', ':tobool',
+	':toid', ':toip', ':toip6', ':tonum', ':tonsec', ':tostr', ':totime', ':tocrlf', ':tolf',
 	-- Boolean values and logical operators.
 	'false', 'no', 'true', 'yes', 'and', 'in', 'or',
 	-- Networking.

--- a/lua/lexers/rpmspec.lua
+++ b/lua/lexers/rpmspec.lua
@@ -1,4 +1,4 @@
--- Copyright 2022-2025 Matej Cepl mcepl.att.cepl.eu. See LICENSE.
+-- Copyright 2022-2026 Matej Cepl mcepl.att.cepl.eu. See LICENSE.
 
 local lexer = lexer
 local P, R, S = lpeg.P, lpeg.R, lpeg.S

--- a/lua/lexers/ruby.lua
+++ b/lua/lexers/ruby.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Ruby LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/scheme.lua
+++ b/lua/lexers/scheme.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Scheme LPeg lexer.
 -- Contributions by Murray Calavera.
 

--- a/lua/lexers/smalltalk.lua
+++ b/lua/lexers/smalltalk.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Smalltalk LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/sml.lua
+++ b/lua/lexers/sml.lua
@@ -1,4 +1,4 @@
--- Copyright 2017-2025 Murray Calavera. See LICENSE.
+-- Copyright 2017-2026 Murray Calavera. See LICENSE.
 -- Standard ML LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/snobol4.lua
+++ b/lua/lexers/snobol4.lua
@@ -1,4 +1,4 @@
--- Copyright 2013-2025 Michael T. Richter. See LICENSE.
+-- Copyright 2013-2026 Michael T. Richter. See LICENSE.
 -- SNOBOL4 lexer.
 -- This lexer works with classic SNOBOL4 as well as the CSNOBOL4 extensions.
 

--- a/lua/lexers/sql.lua
+++ b/lua/lexers/sql.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- SQL LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/strace.lua
+++ b/lua/lexers/strace.lua
@@ -1,4 +1,4 @@
--- Copyright 2017-2025 Marc André Tanner. See LICENSE.
+-- Copyright 2017-2026 Marc André Tanner. See LICENSE.
 -- strace(1) output lexer
 
 local lexer = lexer

--- a/lua/lexers/swift.lua
+++ b/lua/lexers/swift.lua
@@ -1,0 +1,122 @@
+-- Copyright 2026 Mitchell. See LICENSE.
+-- Swift LPeg lexer.
+
+local lexer = lexer
+local P, S, B = lpeg.P, lpeg.S, lpeg.B
+
+local lex = lexer.new(...)
+
+-- Keywords.
+lex:add_rule('keyword', lex:tag(lexer.KEYWORD, lex:word_match(lexer.KEYWORD)))
+
+-- Types.
+local constant = lexer.upper * (lexer.upper + '_')^0 * -lexer.alnum
+lex:add_rule('type', lex:tag(lexer.TYPE, #lexer.upper * -constant * lexer.word)) -- convention
+
+-- Functions.
+local builtin_func = -B('.') *
+	lex:tag(lexer.FUNCTION_BUILTIN, lex:word_match(lexer.FUNCTION_BUILTIN))
+local func = lex:tag(lexer.FUNCTION, lexer.word)
+local method = B('.') * lex:tag(lexer.FUNCTION_METHOD, lexer.word)
+lex:add_rule('function', (builtin_func + method + func) * #(lexer.space^0 * '('))
+
+-- Identifiers.
+lex:add_rule('identifier', lex:tag(lexer.IDENTIFIER, lexer.word + '`' * lexer.word * '`' +
+	('$' * (lexer.digit^1 + lexer.word))))
+
+-- Comments.
+local line_comment = lexer.to_eol('//', true)
+local block_comment = lexer.range('/*', '*/')
+lex:add_rule('comment', lex:tag(lexer.COMMENT, line_comment + block_comment))
+
+-- Strings.
+local dq_str = P('#')^0 * lexer.range('"', true) * P('#')^0 -- TODO: balanced #
+local ml_str = lexer.range('"""')
+local string = lex:tag(lexer.STRING, ml_str + dq_str)
+local regex_str = lexer.after_set('+-*%^!=&|?:;,([{<>',
+	lexer.range('/', true) + lexer.range('#/', '/#')) -- TODO: multiple, balanced # are allowed
+local regex = lex:tag(lexer.REGEX, regex_str)
+lex:add_rule('string', string + regex)
+
+-- Numbers.
+lex:add_rule('number', lex:tag(lexer.NUMBER, lexer.number_('_')))
+
+-- Preprocessor.
+lex:add_rule('preproc', lex:tag(lexer.PREPROCESSOR, '#' * lex:word_match(lexer.PREPROCESSOR)))
+
+-- Attributes.
+lex:add_rule('attribute', lex:tag(lexer.ANNOTATION,
+	'@' * (lex:word_match('attribute') + lexer.upper * lexer.word)))
+
+-- Operators.
+lex:add_rule('operator', lex:tag(lexer.OPERATOR, S('+-/*%^~!=&|?:;,.()[]{}<>')))
+
+-- Fold points.
+lex:add_fold_point(lexer.OPERATOR, '{', '}')
+lex:add_fold_point(lexer.COMMENT, '/*', '*/')
+lex:add_fold_point(lexer.PREPROCESSOR, '#if', '#endif')
+
+-- Word lists.
+lex:set_word_list(lexer.KEYWORD, {
+	-- Declarations.
+	'associatedtype', 'borrowing', 'class', 'consuming', 'deinit', 'enum', 'extension', 'fileprivate',
+	'func', 'import', 'init', 'inout', 'internal', 'let', 'nonisolated', 'open', 'operator',
+	'precedencegroup', 'private', 'protocol', 'public', 'rethrows', 'static', 'struct', 'subscript',
+	'typealias', 'var',
+	-- Statements.
+	'break', 'case', 'catch', 'continue', 'default', 'defer', 'do', 'else', 'fallthrough', 'for',
+	'guard', 'if', 'in', 'repeat', 'return', 'switch', 'throw', 'where', 'while',
+	-- Expressions and types.
+	'Any', 'as', 'await', 'catch', 'false', 'is', 'nil', 'rethrows', 'self', 'Self', 'super', 'throw',
+	'throws', 'true', 'try',
+	-- Patterns.
+	'_',
+	-- Context-specific.
+	'associativity', 'async', 'convenience', 'didSet', 'dynamic', 'final', 'get', 'indirect', 'infix',
+	'lazy', 'left', 'mutating', 'none', 'nonmutating', 'optional', 'override', 'package', 'postfix',
+	'precedence', 'prefix', 'Protocol', 'required', 'right', 'set', 'some', 'Type', 'unowned', 'weak',
+	'willSet'
+})
+
+lex:set_word_list(lexer.FUNCTION_BUILTIN, {
+	-- Numbers and basic values.
+	'numericCast', 'all', 'any', 'pointwiseMax', 'pointwiseMin', 'min', 'max', 'abs',
+	-- Collections.
+	'stride', 'repeatElement', 'sequence', 'zip', 'isKnownUniquelyReferenced',
+	-- Input and output.
+	'print', 'readLine', 'debugPrint', 'dump', 'assert', 'assertionFailure', 'precondition',
+	'preconditionFailure', 'fatalError', 'type',
+	-- Concurrency.
+	'withTaskGroup', 'withThrowingTaskGroup', 'withDiscardingTaskGroup',
+	'withThrowingDiscardingTaskGroup', 'withCheckedContinuation', 'withCheckedThrowingContinuation',
+	'withUnsafeContinuation', 'withUnsafeThrowingContinuation', 'withTaskExecutorPreference',
+	-- Manual memory management.
+	'withUnsafePointer', 'withUnsafeMutablePointer', 'withUnsafeBytes', 'withUnsafeMutableBytes',
+	'withUnsafeTemporaryAllocation', 'swap', 'exchange', 'withExtendedLifetime', 'extendLifetime',
+	-- Type casting and existential types.
+	'withoutActuallyEscaping', 'unsafeDowncast', 'unsafeBitCast',
+	-- C interoperability.
+	'withVaList', 'getVaList'
+})
+
+lex:set_word_list(lexer.PREPROCESSOR, {
+	'available', 'colorLiteral', 'else', 'elseif', 'endif', 'fileLiteral', 'if', 'imageLiteral',
+	'keyPath', 'selector', 'sourceLocation', 'unavailable'
+})
+
+lex:set_word_list('attribute', {
+	-- Declaration.
+	'available', 'backDeployed', 'discardableResult', 'dynamicCallable', 'dynamicMemberLookup',
+	'export', 'freestanding', 'frozen', 'GKInspectable', 'globalActor', 'inlinable', 'main',
+	'nonobjc', 'NSApplicationMain', 'NSCopying', 'NSManaged', 'objc', 'objcMembers', 'preconcurrency',
+	'propertyWrapper', 'resultBuilder', 'requires_stored_property_inits', 'testable',
+	'UIApplicationMain', 'unchecked', 'usableFromInline', 'warn_unqualified_access',
+	-- Type.
+	'autoclosure', 'convention', 'escaping', 'Sendable',
+	-- Switch.
+	'unknown'
+})
+
+lexer.property['scintillua.comment'] = '//'
+
+return lex

--- a/lua/lexers/template.txt
+++ b/lua/lexers/template.txt
@@ -1,4 +1,4 @@
--- Copyright 2022-2025 Mitchell. See LICENSE.
+-- Copyright 2022-2026 Mitchell. See LICENSE.
 -- ? LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/tex.lua
+++ b/lua/lexers/tex.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Plain TeX LPeg lexer.
 -- Modified by Robert Gieseke.
 

--- a/lua/lexers/text.lua
+++ b/lua/lexers/text.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Text LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/troff.lua
+++ b/lua/lexers/troff.lua
@@ -1,4 +1,4 @@
--- Copyright 2023-2025 Mitchell. See LICENSE.
+-- Copyright 2023-2026 Mitchell. See LICENSE.
 -- troff/man LPeg lexer.
 -- Based on original Man lexer by David B. Lamkins and modified by Eolien55.
 

--- a/lua/lexers/typescript.lua
+++ b/lua/lexers/typescript.lua
@@ -1,4 +1,4 @@
--- Copyright 2021-2025 Mitchell. See LICENSE.
+-- Copyright 2021-2026 Mitchell. See LICENSE.
 -- TypeScript LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/vala.lua
+++ b/lua/lexers/vala.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Vala LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/vb.lua
+++ b/lua/lexers/vb.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- VisualBasic LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/verilog.lua
+++ b/lua/lexers/verilog.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- Verilog LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/vhdl.lua
+++ b/lua/lexers/vhdl.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- VHDL LPeg lexer.
 
 local lexer = require('lexer')

--- a/lua/lexers/wsf.lua
+++ b/lua/lexers/wsf.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- WSF LPeg lexer (based on XML).
 -- Contributed by Jeff Stone.
 

--- a/lua/lexers/xml.lua
+++ b/lua/lexers/xml.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- XML LPeg lexer.
 
 local lexer = lexer

--- a/lua/lexers/yaml.lua
+++ b/lua/lexers/yaml.lua
@@ -1,4 +1,4 @@
--- Copyright 2006-2025 Mitchell. See LICENSE.
+-- Copyright 2006-2026 Mitchell. See LICENSE.
 -- YAML LPeg lexer.
 -- It does not keep track of indentation perfectly.
 


### PR DESCRIPTION
	Bugfixes:
	- Fixed PKGBUILD lexer to not tag keywords after '.' and numbers that are parts of words. Changes:
	- Updated RouterOS lexer keywords.
	- Updated PKGBUILD lexer keywords, functions, and constants.
	- Added Swift lexer.
	- Added Arduino lexer.
	- Updated Go lexer with new functions.
	- Various Perl lexer improvements.
	- Recognize more extensions for C++, diff, Javascript, Makefile, Powershell, and Python lexers.
	- Added lexer.ignore_extensions and lexer.ignore_patterns for ignoring extensions and filename parts, respectively, in lexer.detect().
	- Added more LaTeX math environment keywords.
	- Updated Lua lexer to reflect changes in Lua 5.5.
	- Dart lexer recognizes capitalized words as types.