### PR TITLE
build: remove vis from .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,4 +172,4 @@ uninstall:
 	@echo removing support files from ${DESTDIR}${SHAREPREFIX}/vis
 	@rm -rf ${DESTDIR}${SHAREPREFIX}/vis
 
-.PHONY: all clean vis dist distclean install install-strip uninstall debug profile coverage test test-update luadoc luadoc-all luacheck man docker-kill docker docker-clean
+.PHONY: all clean dist distclean install install-strip uninstall debug profile coverage test test-update luadoc luadoc-all luacheck man docker-kill docker docker-clean


### PR DESCRIPTION
With `vis` in `.PHONY` the executable was rebuilt on every call of `make`. The same was true for `make install`, causing trouble with the debug package when building a distribution package.