### PR TITLE
Fixed memory fault on window redraw when sidebar is displayed

### DIFF
--- a/ui-terminal.c
+++ b/ui-terminal.c
@@ -225,12 +225,9 @@ static void ui_window_draw(Win *win) {
 	View *view = &win->view;
 	const Line *line = win->view.topline;
 
-	bool status  = win->options & UI_OPTION_STATUSBAR;
 	bool nu      = win->options & UI_OPTION_LINE_NUMBERS_ABSOLUTE;
 	bool rnu     = win->options & UI_OPTION_LINE_NUMBERS_RELATIVE;
 	bool sidebar = nu || rnu;
-
-	int width = win->width, height = win->height;
 
 	int sidebar_width = 0;
 	if (sidebar) {
@@ -238,7 +235,6 @@ static void ui_window_draw(Win *win) {
 		sidebar_width = MAX(sidebar_width, win->min_sidebar_width);
 	}
 	if (sidebar_width != win->sidebar_width) {
-		view_resize(view, width - sidebar_width, status ? height - 1 : height);
 		win->sidebar_width = sidebar_width;
 	}
 	vis_window_draw(win);


### PR DESCRIPTION
# Problem
Occasional crashes when opening a file in vis and moving around while the sidebar is activated (`:set nu` or `:set rnu`). Though the fix removes resizing the view when sidebar size changes, I couldn't notice any rendering issues, so far.

# Steps to reproduce
- open a file, e.g. attached file `view.txt`
- `:set numbers`
- go to bottom of a file with `G`
- enlarge the editor window
- hit `gg`

... but there are also other ways to trigger this bug.

# Vis version
vis v0.9-466-gca7bc199-dirty +curses +lua +selinux
vis commit ca7bc1997e3d0e944cff3eb75eb3b44d7619ec00
(same occurs with older versions, it has been following me for quite a while)

# Vis config
    # This version of config.mk was generated by:
    # ./configure CFLAGS='-g -O0'
    # Any changes made here will be lost if configure is re-run
    SRCDIR = .
    PREFIX = /usr/local
    EXEC_PREFIX = $(PREFIX)
    BINDIR = $(EXEC_PREFIX)/bin
    DOCPREFIX = $(PREFIX)/share/doc
    MANPREFIX = $(PREFIX)/share/man
    SHAREPREFIX = $(PREFIX)/share
    CC = cc
    CFLAGS = -g -O0 -Wall -pipe -Wno-initializer-overrides -ffunction-sections -fdata-sections -fPIE
    LDFLAGS = -Wl,-z,now -Wl,-z,relro
    CFLAGS_STD = -std=c99 -DNDEBUG
    LDFLAGS_STD = -lc
    CFLAGS_AUTO = -fstack-protector-all
    LDFLAGS_AUTO = -Wl,--gc-sections -pie
    CFLAGS_DEBUG = -U_FORTIFY_SOURCE -UNDEBUG -O0 -g3 -ggdb -Wall -Wextra -pedantic -Wno-missing-field-initializers -Wno-unused-parameter
    CFLAGS_TERMKEY = -DTERMINFO='"/usr/share/terminfo"' -DTERMINFO_DIRS='"/usr/share/terminfo"'
    CFLAGS_CURSES = -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -DCONFIG_CURSES=1
    LDFLAGS_CURSES = -lncursesw
    CFLAGS_TRE = 
    LDFLAGS_TRE = 
    CFLAGS_LUA = -I/usr/include/lua5.3 -DCONFIG_LUA=1
    LDFLAGS_LUA = -llua5.3
    CFLAGS_LPEG = 
    LDFLAGS_LPEG = 
    CFLAGS_ACL = 
    LDFLAGS_ACL = 
    CFLAGS_SELINUX =  -DCONFIG_SELINUX=1
    LDFLAGS_SELINUX = -lselinux

# Terminal name/version
st 0.8.5
$TERM=st-256color

# Debugging
## Changes made for debugging:
1. Commented out line 253 in `configure`:
    `tryflag CFLAGS -O2`

2. Turned off optimizations for debugging core file:
    `% ./configure CFLAGS='-g -O0'`

## Core file attached (core.vis.6086)
crash in ui-terminal.c:256, in `ui_window_draw()` while accessing `*l` which points to unaccessible memory

## Valgrind
memory is allocated in view.c:545, in `view_resize()` with `realloc(view->lines, ...)`

## Screenshot attached
core.vis.6086.screenshot.png

