### PR TITLE
Fix completion of words without submitted characters in prefix

### DIFF
--- a/lua/plugins/complete-word.lua
+++ b/lua/plugins/complete-word.lua
@@ -26,7 +26,8 @@ vis:map(vis.modes.INSERT, "<C-n>", function()
 		candidates = table.concat(candidates, "\n")
 		local status, out, err = vis:pipe(candidates, "sort -u | vis-menu -b")
 		if status == 0 and out then
-			out = out:sub(#prefix + 1, #out - 1)
+			local start = out:sub(1, #prefix) == prefix and #prefix + 1 or 1
+			out = out:sub(start, -2)
 			file:insert(pos, out)
 			win.selection.pos = pos + #out
 		else


### PR DESCRIPTION
When using `<C-n>` to do auto-completion without having typed the beginning of a word, `prefix` is whatever character came before the cursor position. In this case `#prefix` is `1`.

When appending the selected completion match, `#prefix` is subtracted from the match before the remaining characters of the match are written to `pos`.

When `prefix` is not part of the match, `#prefix` should not be taken into account for character subractiion, since that results in chars being lost from the result.

This fixes that.

Resolves https://github.com/martanne/vis/issues/1361