### PR TITLE
lua: add vis.API to make feature checks easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,10 @@ MANUALS = $(EXECUTABLES:=.1)
 DOCUMENTATION = LICENSE README.md
 
 VERSION = $(shell git describe --always --dirty 2>/dev/null || echo "v0.9-git")
+API     = $(shell git rev-list --count HEAD 2>/dev/null || echo "0")
 
 CFLAGS_STD ?= -std=c99 -DNDEBUG
-CFLAGS_STD += -DVERSION=\"${VERSION}\"
+CFLAGS_STD += -DVERSION=\"${VERSION}\" -DVIS_API=$(API)
 LDFLAGS_STD ?= -lc
 
 CFLAGS_VIS = $(CFLAGS_AUTO) $(CFLAGS_TERMKEY) $(CFLAGS_CURSES) $(CFLAGS_ACL) \

--- a/util.h
+++ b/util.h
@@ -1,6 +1,13 @@
 #ifndef UTIL_H
 #define UTIL_H
 
+#ifndef VERSION
+  #define VERSION "unknown"
+#endif
+#ifndef VIS_API
+  #define VIS_API 0
+#endif
+
 #ifndef VIS_INTERNAL
   #define VIS_INTERNAL static
 #endif

--- a/vis-lua.c
+++ b/vis-lua.c
@@ -486,6 +486,21 @@ static const char *keymapping(Vis *vis, const char *keys, const Arg *arg) {
  * version information in `git describe` format, same as reported by `vis -v`.
  */
 /***
+ * API Version
+ * @tfield int API
+ * an integer revision count of the commit vis was built with. Meant for plugin authors who want
+ * to write backward compatible plugins.
+ * @usage
+ * local api = vis.API
+ * if not api then
+ * 	local api_string = vis.VERSION:match('v%d*%.(%d*).*')
+ * 	api = api_string and tonumber(api_string) or 0
+ * end
+ * if api > 3160 then
+ * 	-- use feature only available after revision 3160
+ * end
+ */
+/***
  * Lua API object types
  * @field types meta tables of userdata objects used for type checking
  * @local
@@ -3363,6 +3378,9 @@ static void vis_lua_init(Vis *vis)
 
 	lua_pushliteral(L, VERSION);
 	lua_setfield(L, -2, "VERSION");
+
+	lua_pushinteger(L, VIS_API);
+	lua_setfield(L, -2, "API");
 
 	// NOTE: vis.ui table
 	lua_newtable(L);


### PR DESCRIPTION
Ignoring a few times in the early git history we now always maintain a linear revision list. This means we can use a revision counter like SVN to provide a method of doing an ordered version comparison. This allows plugin authors who care about backwards compatibility with older versions of vis to simply check the revision counter to know if a feature is available. This can allow authors to enable and disable features during ~~vis.INIT~~ plugin load instead of having to do runtime checks with pcall().

@fischerling as someone who has lots of backwards compatibility checks in your plugins, is something like this useful? Can you think of any improvements? Note I included an example in the documentation for what to do when `vis.API` is `nil` (i.e. vis was built prior to the commit in this PR).