### PR TITLE
Fix: pasting the dot-register (last inserted text) verbally pastes symbolic keys

### DIFF
--- a/vis-operators.c
+++ b/vis-operators.c
@@ -37,7 +37,24 @@ static size_t op_put(Vis *vis, Text *txt, OperatorContext *c) {
 	size_t pos = c->pos;
 	bool sel = text_range_size(c->range) > 0;
 	bool sel_linewise = sel && text_range_is_linewise(txt, c->range);
-	if (sel) {
+	if (vis_register_used(vis) == VIS_REG_DOT) {
+		/* Macro-replaying the dot-register prevents that op_put() is executed multiple times if
+		 * there is more than one selection, so deletion of multiple selections needs to be done
+		 * before replaying the macro. */
+		for (Selection *s = view_selections(&vis->win->view); s; s = view_selections_next(s)) {
+			Filerange r = view_selections_get(s);
+			size_t start = r.start;
+			if (text_range_size(r) > 1) {
+				text_delete_range(txt, r);
+			} else {
+				/* Also move the cursor of all selections one char further if putting with 'p' */
+				if (c->arg->i == VIS_OP_PUT_AFTER || c->arg->i == VIS_OP_PUT_AFTER_END)
+					start = text_char_next(txt, start);
+			}
+			view_cursors_to(s, start);
+		}
+	}
+	else if (sel) {
 		text_delete_range(txt, c->range);
 		pos = c->pos = c->range.start;
 	}
@@ -57,22 +74,21 @@ static size_t op_put(Vis *vis, Text *txt, OperatorContext *c) {
 	}
 
 	if (vis_register_used(vis) == VIS_REG_DOT) {
-		vis_mode_switch(vis, VIS_MODE_INSERT);
 		vis_macro_replay(vis, VIS_REG_DOT);
-		return EPOS;
-	}
+		pos = EPOS;
+	} else {
+		s64 len;
+		const char *data = register_slot_get(vis, c->reg, c->reg_slot, &len);
 
-	s64 len;
-	const char *data = register_slot_get(vis, c->reg, c->reg_slot, &len);
-
-	for (int i = 0; i < c->count; i++) {
-		char nl;
-		if (c->reg->linewise && pos > 0 && text_byte_get(txt, pos-1, &nl) && nl != '\n')
-			pos += text_insert(vis, txt, pos, "\n", 1);
-		text_insert(vis, txt, pos, data, len);
-		pos += len;
-		if (c->reg->linewise && pos > 0 && text_byte_get(txt, pos-1, &nl) && nl != '\n')
-			pos += text_insert(vis, txt, pos, "\n", 1);
+		for (int i = 0; i < c->count; i++) {
+			char nl;
+			if (c->reg->linewise && pos > 0 && text_byte_get(txt, pos-1, &nl) && nl != '\n')
+				pos += text_insert(vis, txt, pos, "\n", 1);
+			text_insert(vis, txt, pos, data, len);
+			pos += len;
+			if (c->reg->linewise && pos > 0 && text_byte_get(txt, pos-1, &nl) && nl != '\n')
+				pos += text_insert(vis, txt, pos, "\n", 1);
+		}
 	}
 
 	if (c->reg->linewise) {

--- a/vis-operators.c
+++ b/vis-operators.c
@@ -56,6 +56,12 @@ static size_t op_put(Vis *vis, Text *txt, OperatorContext *c) {
 		break;
 	}
 
+	if (vis_register_used(vis) == VIS_REG_DOT) {
+		vis_mode_switch(vis, VIS_MODE_INSERT);
+		vis_macro_replay(vis, VIS_REG_DOT);
+		return EPOS;
+	}
+
 	s64 len;
 	const char *data = register_slot_get(vis, c->reg, c->reg_slot, &len);
 

--- a/vis.c
+++ b/vis.c
@@ -840,9 +840,13 @@ void vis_do(Vis *vis) {
 		}
 
 		if (a->op) {
+			/* Save the register before it will be altered by the following operator call */
+			int reg_used = vis_register_used(vis);
 			size_t pos = a->op->func(vis, txt, &c);
 			if (pos == EPOS) {
-				view_selections_dispose(sel);
+				/* The first selection needs to be kept when putting the dot-register */
+				if (reg_used != VIS_REG_DOT)
+					view_selections_dispose(sel);
 			} else if (pos <= text_size(txt)) {
 				view_selection_clear(sel);
 				view_cursors_to(sel, pos);
@@ -1403,8 +1407,12 @@ bool vis_macro_replay(Vis *vis, enum VisRegister id) {
 		return false;
 	int count = VIS_COUNT_DEFAULT(vis->action.count, 1);
 	vis_cancel(vis);
-	for (int i = 0; i < count; i++)
+	for (int i = 0; i < count; i++) {
+		if (id == VIS_REG_DOT)
+			/* switch to insert mode before replaying the dot-register */
+			vis_mode_switch(vis, VIS_MODE_INSERT);
 		macro_replay(vis, macro);
+	}
 	Win *win = vis->win;
 	if (win)
 		vis_file_snapshot(vis, win->file);


### PR DESCRIPTION
When pasting the dot-register, symbolic keys like `<Escape>, <Enter>, <Left>, <Right>`, ... are inserted as text and not executed. Thus, the text `<Escape>` is always appended, and if multiple lines were inserted or a cursor key was used while inserting, the corresponding text for these keys is inserted. For example, when inserting two lines and then pasting the last insert with `".p`, the pasted text looks like:
```
line1<Enter>line2<Enter><Escape>
```
Instead of pasting the contents of the dot-register verbally, this fix switches to insert mode and then replays the content of the dot-register like a macro. The resulting text from the example then looks like:
```
line1
line2
```