### PR TITLE
Disable now useless 8-bit mode

### DIFF
--- a/ui-terminal-curses.c
+++ b/ui-terminal-curses.c
@@ -264,7 +264,6 @@ ui_backend_init(Ui *ui, char *term)
 		noecho();
 		nonl();
 		keypad(stdscr, TRUE);
-		meta(stdscr, TRUE);
 		curs_set(0);
 
 		pair_content(0, &ui->curses.default_fg, &ui->curses.default_bg);


### PR DESCRIPTION
Enabling 8-bit mode was rendered useless when switching to libtermkey as the input handler. This also causes issues with terminals honoring the `smm` property (metaSendsEscape) by stripping the Alt sequence and should thus be removed.

Fixes #1252