### PR TITLE
CI: build and test on FreeBSD and OpenBSD

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,40 @@
+name: FreeBSD
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - ""
+          - --disable-curses
+          - --disable-lua
+          - --disable-tre
+          - --disable-help
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Build and test in a FreeBSD vm
+      uses: vmactions/freebsd-vm@v1
+      with:
+        release: "15.1"
+        usesh: true
+        copyback: false
+        cache-after-prepare: true
+        prepare: |
+          pkg install -y gmake lua53 lua53-lpeg pkgconf libtre
+        run: |
+          set -e
+          ./configure ${{ matrix.config }}
+          # gmake, not make: the Makefile uses $(shell ...) for VERSION and
+          # API, which BSD make does not implement.  Under BSD make both
+          # expand to nothing, and the empty -DVIS_API= then defeats the
+          # "#ifndef VIS_API" fallback in util.h, so vis-lua.c fails to
+          # compile with "error: expected expression".
+          gmake
+          gmake test

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -1,0 +1,35 @@
+name: OpenBSD
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - ""
+          - --disable-curses
+          - --disable-lua
+          - --disable-help
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Build and test in an OpenBSD vm
+      uses: vmactions/openbsd-vm@v1
+      with:
+        release: "7.9"
+        usesh: true
+        copyback: false
+        cache-after-prepare: true
+        prepare: |
+          pkg_add -I gmake lua%5.3 lua53-lpeg
+        run: |
+          set -e
+          ./configure ${{ matrix.config }}
+          # gmake, not make: see the comment in freebsd.yml.
+          gmake
+          gmake test


### PR DESCRIPTION
The sourcehut builds stopped running on 2026-02-06.  builds.sr.ht shows
no job after #1674603, and 119 commits have landed since; the badge in
README still reads success from that last run.

    https://builds.sr.ht/~martanne/vis

This adds a FreeBSD job and an OpenBSD job that run in VMs on
GitHub-hosted runners, so a BSD result appears on every push and pull
request here, next to Ubuntu and macOS.


gmake, not make
---------------

Both jobs call gmake rather than make, and .builds/freebsd.yml and
.builds/openbsd.yml would fail today because they call make.

The Makefile computes two values with $(shell ...), which is a GNU make
extension:

    VERSION = $(shell git describe --always --dirty 2>/dev/null || echo "v0.9-git")
    API     = $(shell git rev-list --count HEAD 2>/dev/null || echo "0")

BSD make does not implement it, so under make both expand to nothing --
the fallbacks never get a chance to run either.  -DVERSION=\"\" is a
harmless empty string, but -DVIS_API= is an empty macro that still
counts as defined, so the

    #ifndef VIS_API
      #define VIS_API 0
    #endif

fallback in util.h does not fire, and vis-lua.c:3391 becomes
lua_pushinteger(L, ):

    ./vis-lua.c:3391:28: error: expected expression
     3391 |         lua_pushinteger(L, VIS_API);
          |                                   ^

$(shell ...) has been in the Makefile since 2015, but it only started
breaking the build on 2026-06-26, when 0515140c added vis.API and gave
VIS_API a use site where an empty expansion is not valid C.  That is
four months after the sourcehut builds stopped, which is why it went
unnoticed.

Under gmake the fallbacks work: the VM has no .git, so both shell
commands fail and VERSION becomes "v0.9-git" and VIS_API becomes 0.


What the jobs cover
-------------------

The same configure variants the ubuntu and macOS jobs use:

    FreeBSD 15.1   ""  --disable-curses  --disable-lua
                   --disable-tre  --disable-help
    OpenBSD 7.9    ""  --disable-curses  --disable-lua  --disable-help

OpenBSD has no --disable-tre entry because 7.9 packages no libtre, so
configure already reports "checking for libtre... no" there and the
default build has no tre to disable.

Results, from
https://github.com/neilpang/vis/actions/runs/31863428494 and
https://github.com/neilpang/vis/actions/runs/31863428537 :

    FreeBSD  5/5 green, 1.9 to 2.1 min per config
    OpenBSD  4/4 green, 2.9 to 3.3 min per config

    every config: Tests ok 8/8, Tests ok 65/65,
                  Tests ok 6/6 skipped 28, no failures

    --disable-lua drops the two lua suites, as it should, and the
    binary reports +curses +tre with no +lua


One thing this does not fix
---------------------------

7d53cd6f added five calls to towlower, towupper and iswlower in main.c
without including <wctype.h>; nothing in the tree includes it.  Both
BSDs warn five times:

    main.c:393:11: warning: call to undeclared function 'towlower';
    ISO C99 and later do not support implicit function declarations
    [-Wimplicit-function-declaration]

These are warnings and not what breaks the build, so the jobs are green
with them present.  They are invalid C99 though, and would become errors
under a compiler that defaults to rejecting implicit declarations.  I
left it alone since it is a separate change from adding CI; happy to
send it as its own PR if you want it.


Left alone deliberately
-----------------------

  - .builds/freebsd.yml and .builds/openbsd.yml, README's sourcehut
    badge: what you want to do with sourcehut is your call.
  - No coverage upload.  The ubuntu and macOS jobs build with
    --coverage and push to codecov; the sourcehut builds never did, and
    the .gcda files would have to be copied back out of the VM first.
    Easy to add if you want it.
  - actions/checkout is @v7 in the new files while the existing ones
    are on @v6.  I did not touch them, to keep this to one change.
