### PR TITLE
test/util: silence build warnings with vendored termkey

### DIFF
--- a/test/util/Makefile
+++ b/test/util/Makefile
@@ -2,7 +2,7 @@
 
 keys: keys.c
 	@echo Compiling keys utility
-	$(CC) $(CFLAGS) -I../.. keys.c $(LDFLAGS) $(LDFLAGS_CURSES) -o keys
+	$(CC) $(CFLAGS) -I../.. keys.c $(LDFLAGS) $(LDFLAGS_CURSES) -Wno-unused-function -o keys
 
 clean:
 	@echo cleaning


### PR DESCRIPTION
Now that we have the termkey source in our own tree the build spits some warnings about unused functions. Silence these warnings, it is expected for the test util.