### PR TITLE
no syntax highlighting option

### DIFF
--- a/lua/plugins/filetype.lua
+++ b/lua/plugins/filetype.lua
@@ -322,6 +322,7 @@ local function GetHashBang(data)
 	return hb, utility
 end
 
+M.default_syntax = "text" -- should never be nil
 
 -- Returns syntax/filetype
 -- utility -> datap -> filename -> extension -> L.detect() -> mime
@@ -365,7 +366,7 @@ local function Detect(file)
 		end
 	end
 
-	local path = file.name -- filepath
+	local path = file.path or file.name -- filepath
 	local name
 	if path and path~="" then
 		name = path and path:match("[^/]+$") -- filename
@@ -416,12 +417,30 @@ local function Detect(file)
 		end
 	end
 
-	return 'text'
-end
+	return M.default_syntax
+end M.Detect = Detect
 
-vis.events.subscribe(vis.events.WIN_OPEN, function(win)
-	local syntax = Detect(win.file) -- syntax/lexer/filetype
-	local filetype = rawget(filetypes, syntax) -- avoid backwards compatibility mt
+local FindSyntax
+= function --> syntax: string --
+(
+	win -- vis.win|nil
+)
+	if win then
+		local syntax = win.file.path==nil -- empty window
+			and M.default_syntax -- should be "text"
+			or Detect(win.file) -- syntax/lexer/filetype
+		return syntax
+	end
+	return M.default_syntax
+end
+M.FindSyntax = FindSyntax
+
+local SetActions
+= function --> syntax: string
+(
+	win -- vis.win
+)
+	local filetype = rawget(filetypes, win.SYNTAX) -- avoid backwards compatibility mt
 	if filetype then
 		for _, Action in ipairs(filetype.actions or {}) do
 			Action(win, filetype)
@@ -429,29 +448,51 @@ vis.events.subscribe(vis.events.WIN_OPEN, function(win)
 		for _, cmd in ipairs(filetype.cmd or {}) do
 			vis:command(cmd)
 		end
-		syntax = filetype.lexer
+		win.SYNTAX = filetype.lexer
 			or filetype.alt_name -- backwards compat
-			or syntax
+			or win.SYNTAX
 	end
-	-- Detect returns filetype, lexer is optional
-	if package.searchpath("lexers." .. syntax, package.path) then
-		win:set_syntax(syntax)
-		return
-	else
+end
+M.SetActions = SetActions
+
+local ChangeSyntax
+= function --> nil|syntax: string
+(
+	win -- vis.win
+)
+	if win.syntax_highlight then
+		local syntax = win.SYNTAX
+		-- Detect returns filetype, lexer is optional
+		if package.searchpath("lexers." .. syntax, package.path) then
+			win:set_syntax(syntax)
+			return syntax
+		end
 		vis:info(
 			string.format(
 				"Lexer '%s' not found", syntax
 			)
 		)
 	end
+	win.syntax = nil
+end
+M.ChangeSyntax = ChangeSyntax
 
-	win:set_syntax(nil)
-	return
-end)
+local SwitchSyntax = function (win)
+	local syntax = FindSyntax(win)
+	win.SYNTAX = syntax
+	SetActions(win)
+	local globopt = vis.options.SYNTAX_HIGHLIGHT
+	win.syntax_highlight = globopt
+	if globopt then ChangeSyntax(win) end
+end
+vis.events.subscribe(vis.events.WIN_OPEN, SwitchSyntax)
 
-vis.events.subscribe(vis.events.FILE_SAVE_POST, function(file, path)
-	local syntax = Detect(file)
-	if syntax then
-		vis:command("set syntax " .. syntax)
+vis.events.subscribe(vis.events.FILE_SAVE_POST, function (file, path)
+	local win = vis.win
+	if win and win.file==file and file.win==nil then
+		file.win = win
+		SwitchSyntax(win)
 	end
 end)
+
+return M

--- a/lua/vis-std.lua
+++ b/lua/vis-std.lua
@@ -54,14 +54,53 @@ vis:option_register("theme", "string", function(name)
 	return true
 end, "Color theme to use, filename without extension")
 
-vis:option_register("syntax", "string", function(name)
-	if not vis.win then return false end
-	if not vis.win:set_syntax(name) then
-		vis:info(string.format("Unknown syntax definition: `%s'", name))
-		return false
+
+-- syntax_highlight is on by default, unless $NO_COLOR is set
+vis.options.SYNTAX_HIGHLIGHT = not(os.getenv"NO_COLOR" or os.getenv"VIS_NOCOLOR")
+-- NOTE: .options.SYNTAX_HIGHLIGHT is used as the real option because modifying
+-- .options.syntax_highlight leads to a C stack overflow, possible BUG?
+-- You also cannot set win.options[key], this one is not a bug, it works
+-- if you have direct access to win, but if you do vis:windows(), you can't see it.
+
+-- global syntax highlight option
+vis:option_register("syntax_highlight", "bool"
+,	function(value, toggle)
+		if toggle then -- value = false
+			value = not vis.options.SYNTAX_HIGHLIGHT
+		end
+		vis.options.SYNTAX_HIGHLIGHT = value
+		if not vis.win then return true end
+		for win in vis:windows() do
+			if win.syntax_highlight ~= value then
+				win.syntax_highlight = value
+				vis.ftdetect.ChangeSyntax(win)
+			end
+		end
+		return true
 	end
-	return true
-end, "Syntax highlighting lexer to use")
+,	"Turns syntax highlighting on/off globally"
+)
+
+-- Per window setting
+vis:option_register("syntax", "string"
+,	function(name)
+		local win = vis.win
+		if not win then return false end
+		if name=="off" then -- current window off
+			win.syntax_highlight = false
+			win.syntax = nil
+			return true
+		elseif name=='on' or name=='auto' then -- default mode
+			win.syntax_highlight = true
+		else
+			win.SYNTAX = name
+			vis.ftdetect.SetActions(win)
+		end
+		vis.ftdetect.ChangeSyntax(win)
+		return true
+	end
+,	"Syntax highlighting lexer to use"
+)
 
 vis:option_register("horizon", "number", function(horizon)
 	if not vis.win then return false end

--- a/lua/vis-std.lua
+++ b/lua/vis-std.lua
@@ -54,14 +54,53 @@ vis:option_register("theme", "string", function(name)
 	return true
 end, "Color theme to use, filename without extension")
 
-vis:option_register("syntax", "string", function(name)
-	if not vis.win then return false end
-	if not vis.win:set_syntax(name) then
-		vis:info(string.format("Unknown syntax definition: `%s'", name))
-		return false
+
+-- syntax_highlight is on by default, unless $NO_COLOR is set
+vis.options.SYNTAX_HIGHLIGHT = not os.getenv"NO_COLOR"
+-- NOTE: .options.SYNTAX_HIGHLIGHT is used as the real option because modifying
+-- .options.syntax_highlight leads to a C stack overflow, possible BUG?
+-- You also cannot set win.options[key], this one is not a bug, it works
+-- if you have direct access to win, but if you do vis:windows(), you can't see it.
+
+-- global syntax highlight option
+vis:option_register("syntax_highlight", "bool"
+,	function(value, toggle)
+		if toggle then -- value = false
+			value = not vis.options.SYNTAX_HIGHLIGHT
+		end
+		vis.options.SYNTAX_HIGHLIGHT = value
+		if not vis.win then return true end
+		for win in vis:windows() do
+			if win.syntax_highlight ~= value then
+				win.syntax_highlight = value
+				vis.ftdetect.ChangeSyntax(win)
+			end
+		end
+		return true
 	end
-	return true
-end, "Syntax highlighting lexer to use")
+,	"Turns syntax highlighting on/off globally"
+)
+
+-- Per window setting
+vis:option_register("syntax", "string"
+,	function(name)
+		local win = vis.win
+		if not win then return false end
+		if name=="off" then -- current window off
+			win.syntax_highlight = false
+			win.syntax = nil
+			return true
+		elseif name=='on' or name=='auto' then -- default mode
+			win.syntax_highlight = true
+		else
+			win.SYNTAX = name
+			vis.ftdetect.SetActions(win)
+		end
+		vis.ftdetect.ChangeSyntax(win)
+		return true
+	end
+,	"Syntax to use"
+)
 
 vis:option_register("horizon", "number", function(horizon)
 	if not vis.win then return false end

--- a/lua/vis.lua
+++ b/lua/vis.lua
@@ -244,15 +244,13 @@ vis.events = events
 -- @tparam string syntax the syntax lexer name or `nil` to disable syntax highlighting
 -- @treturn bool whether the lexer could be changed
 vis.types.window.set_syntax = function(win, syntax)
-
-	local lexers = vis.lexers
-
 	if syntax == nil or syntax == 'off' then
 		win.syntax = nil
 		return true
 	end
 	win.syntax = syntax
 
+	local lexers = vis.lexers
 	if not lexers.load then return false end
 	local lexer = lexers.load(syntax)
 	if not lexer then return false end


### PR DESCRIPTION
Changes:

Environmental Variables:
 Identifies `$NO_COLOR` and `$VIS_NOCOLOR`

Adds `set syntax_highlight BOOLEAN`

Changes functionality of syntax option

`set syntax on` -- sets syntax on of the window
`set syntax off` -- sets syntax off of the window
`set syntax X` -- changes syntax of current window to X

FILE_SAVE_POST only triggers once