### PR TITLE
Fixed some issues with the jump list

### DIFF
--- a/vis-marks.c
+++ b/vis-marks.c
@@ -98,38 +98,63 @@ void vis_mark_set(Vis *vis, Win *win, enum VisMark id, FilerangeList ranges)
 	mark_set(vis, win, mark_from(vis, id), ranges);
 }
 
+static bool jumplist_empty(Win *win)
+{
+	return win->mark_set_lru_cursor == 0 && win->mark_set_lru_regions->count == 0;
+}
+
+static void advance_jumplist_cursor(size_t *cursor, int advance)
+{
+	*cursor += advance;
+	*cursor %= VIS_MARK_SET_LRU_COUNT;
+}
+
+static bool get_jumplist_mark(Vis *vis, FilerangeList *sel, size_t target)
+{
+	Win *win = vis->win;
+	SelectionRegionList *next = win->mark_set_lru_regions + target;
+	if (next->count == 0) return false;  /* attempt to jump to a mark that is not saved, yet */
+	*sel = mark_get(vis, win, next);
+	return true;
+}
+
+static void set_jumplist_mark(Vis *vis, FilerangeList cur)
+{
+	Win *win = vis->win;
+	mark_set(vis, win, win->mark_set_lru_regions + win->mark_set_lru_cursor, cur);
+	win->mark_set_lru_modes[win->mark_set_lru_cursor] = vis->mode->id;
+}
+
 void vis_jumplist(Vis *vis, int advance)
 {
 	Win  *win  = vis->win;
 	View *view = &win->view;
 	FilerangeList cur = view_selections_get_all(vis, view);
 
-	size_t cursor = win->mark_set_lru_cursor;
-	win->mark_set_lru_cursor += advance;
-	if (advance < 0)
-		cursor = win->mark_set_lru_cursor;
-	cursor %= VIS_MARK_SET_LRU_COUNT;
-
-	SelectionRegionList *next = win->mark_set_lru_regions + cursor;
-	bool done = false;
-	if (next->count) {
-		FilerangeList sel = mark_get(vis, win, next);
-		done = vis_mark_equal(sel, cur);
-		if (advance && !done) {
-			/* NOTE: set cached selection */
-			vis_mode_switch(vis, win->mark_set_lru_modes[cursor]);
-			view_selections_set_all(view, sel, view_selections_primary_get(view)->anchored);
+	if (advance) {
+		if (jumplist_empty(win)) goto out;
+		size_t target = win->mark_set_lru_cursor;
+		if (advance > 0) advance_jumplist_cursor(&target, 1);
+		FilerangeList sel;
+		if (!get_jumplist_mark(vis, &sel, target)) goto out;
+		if (vis_mark_equal(sel, cur)) {
+			advance_jumplist_cursor(&target, advance);
+			if (!get_jumplist_mark(vis, &sel, target)) goto out;
 		}
-		da_release(&sel);
+		win->mark_set_lru_cursor = target;
+		vis_mode_switch(vis, win->mark_set_lru_modes[target]);
+		view_selections_set_all(view, sel, view_selections_primary_get(view)->anchored);
+		if (advance < 0) advance_jumplist_cursor(&target, -1);
+	} else {
+		if (jumplist_empty(win)) {
+			set_jumplist_mark(vis, cur);
+			goto out;
+		}
+		advance_jumplist_cursor(&win->mark_set_lru_cursor, 1);
+		set_jumplist_mark(vis, cur);
 	}
 
-	if (!advance && !done) {
-		/* NOTE: save the current selection */
-		mark_set(vis, win, next, cur);
-		win->mark_set_lru_modes[cursor] = vis->mode->id;
-		win->mark_set_lru_cursor++;
-	}
-
+out:
 	da_release(&cur);
 }
 


### PR DESCRIPTION
The current implentation of the jump list has some issues, notably the following two:

1. When changing direction while navigating through the jump list, the mark where the direction is changes is jumped twice. So the cursor is kept on the same mark but it is expected to jump directly to the previous mark.
This can be reproduced by saving three marks in the jump list (in an arbitrary file) on three subsequent lines with:
`gsjgsjgsj`
then navigate back and forth using a sequence like:
`g<g<g>g>`
when changing direction of navigation, `g>` needs to be typed twice before taking any effect.

2. Moving beyond the end of the jump list generates empty, zero-initialized marks that need to be skipped when navigating through them. Creating new and valid jump list entries afterwards leaves empty marks in the list.
To reproduce, store two marks in the jump list:
`gsjg>g>g>gsj`
now, we need to do 5 times `g<` to navigate back to the first mark, instead of having to jump two times only which would be expected in a list of two marks.

The patch below is a rewrite of the jump list handling code and should provide a more correct implementation.

